### PR TITLE
fix view op *args

### DIFF
--- a/cpp_ext/TorchOps.cpp
+++ b/cpp_ext/TorchOps.cpp
@@ -87,6 +87,11 @@ py::object sub(const PyAnyTorchScalarValue &a, const PyAnyTorchScalarValue &b) {
       .value()(returnType, a, b);
 }
 
+PyAnyTorchTensorValue view(PyAnyTorchTensorValue &self, const py::args &args) {
+  auto size = PyAnyTorchListOfTorchIntValue(args);
+  return view(self, size);
+}
+
 void populateTorchMLIROps(py::module &m) {
 
   py::register_exception_translator([](std::exception_ptr p) {
@@ -125,6 +130,13 @@ void populateTorchMLIROps(py::module &m) {
           throw NotImplementedError("aten::avg_pool1d : (Tensor, int[], int[], "
                                     "int[], bool, bool) -> (Tensor)");
         });
+
+  // aten::view : (Tensor, int[]) -> (Tensor)
+  m.def(
+      "view",
+      [](PyAnyTorchTensorValue &self, const py::args &args)
+          -> PyAnyTorchTensorValue { return view(self, args); },
+      "size"_a);
 }
 
 } // namespace mlir::torch

--- a/cpp_ext/TorchOps.h
+++ b/cpp_ext/TorchOps.h
@@ -53,6 +53,9 @@ py::object item(const PyAnyTorchTensorValue &self);
 // py::object sub(const PyAnyTorchScalarValue &a, const PyAnyTorchScalarValue
 // &b);
 
+// aten::view : (Tensor, int[]) -> (Tensor)
+PyAnyTorchTensorValue view(PyAnyTorchTensorValue &self, const py::args &args);
+
 void populateTorchMLIROps(py::module &m);
 
 } // namespace mlir::torch

--- a/cpp_ext/TorchTensor.cpp
+++ b/cpp_ext/TorchTensor.cpp
@@ -210,6 +210,26 @@ void PyAnyTorchTensorValue::bindDerived(ClassTy &c) {
           -> PyAnyTorchTensorValue { return add(self, other, 1.0f); },
       "other"_a);
 
+  // @overload view(self, dtype _dtype) -> Tensor
+  c.def("view",
+        [](const PyAnyTorchTensorValue &self, const PyTorch_IntValue &dtype) {
+          return view_copy(self, dtype);
+        });
+
+  // @overload view(self, size Sequence[Union[_int, SymInt]]) -> Tensor
+  c.def(
+      "view",
+      [](PyAnyTorchTensorValue &self,
+         const PyAnyTorchListOfTorchIntValue &size) {
+        return view(self, size);
+      },
+      "size"_a);
+
+  // @overload view(self, *size _int) -> Tensor
+  c.def("view", [](PyAnyTorchTensorValue &self, const py::args &args) {
+    return view(self, args);
+  });
+
 #include "TorchTensor.pybinds.cpp"
 }
 

--- a/cpp_ext/TorchTensor.pybinds.cpp
+++ b/cpp_ext/TorchTensor.pybinds.cpp
@@ -2404,10 +2404,6 @@ c.def("var", [](const PyAnyTorchTensorValue &self, const PyTorch_BoolValue &unbi
 // vdot(self, other Tensor) -> Tensor
 c.def("vdot", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: vdot with signature vdot(self, other Tensor) -> Tensor"); });
 
-// @overload view(self, size Sequence[Union[_int, SymInt]]) -> Tensor
-// aten::view : (Tensor, int[]) -> (Tensor)
-c.def("view", [](const PyAnyTorchTensorValue &self, const PyAnyTorchListOfTorchIntValue &size) -> PyAnyTorchTensorValue { return view(self, size); }, "size"_a);
-
 // view_as(self, other Tensor) -> Tensor
 c.def("view_as", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: view_as with signature view_as(self, other Tensor) -> Tensor"); });
 


### PR DESCRIPTION
Fixes `ten.view(1, 2, 3, 4)` by adding 

```cpp
  c.def("view", [](PyAnyTorchTensorValue &self, const py::args &args) {
    auto size = PyAnyTorchListOfTorchIntValue(args);
    return view(self, size);
  });
``` 

Note, in order to do this I needed to prevent the autogeneration script from autogenerating that stub/method.