### PR TITLE
DType

### DIFF
--- a/cpp_ext/CMakeLists.txt
+++ b/cpp_ext/CMakeLists.txt
@@ -24,12 +24,14 @@ declare_mlir_python_extension(
   ADD_TO_PARENT
   PiPythonSources
   SOURCES
+  TorchDType.cpp
   TorchTypes.cpp
   TorchValues.cpp
   TorchOps.cpp
   TorchTensor.cpp
   PiExtension.cpp
   # Headers must be included explicitly so they are installed.
+  TorchDType.h
   TorchOps.h
   TorchOps.inc.h
   TorchTensor.h

--- a/cpp_ext/PiExtension.cpp
+++ b/cpp_ext/PiExtension.cpp
@@ -5,6 +5,7 @@
 #include <pybind11/pytypes.h>
 #include <vector>
 
+#include "TorchDType.h"
 #include "TorchOps.h"
 #include "TorchTensor.h"
 #include "TorchTypes.h"
@@ -18,6 +19,7 @@ PYBIND11_MODULE(_pi_mlir, m) {
   populateTorchMLIRTypes(m);
   populateTorchMLIRValues(m);
   populateTorchTensorOps(m);
+  populateTorchDType(m);
   auto ops = m.def_submodule("ops");
   populateTorchMLIROps(ops);
 }

--- a/cpp_ext/TorchDType.cpp
+++ b/cpp_ext/TorchDType.cpp
@@ -1,0 +1,168 @@
+//
+// Created by maksim on 6/13/23.
+//
+
+#include "IRModule.h"
+#include "TorchTypes.h"
+#include "mlir-c/BuiltinTypes.h"
+
+#include "TorchDType.h"
+
+#include <pybind11/cast.h>
+#include <pybind11/detail/common.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+using namespace mlir::python;
+
+namespace mlir::torch {
+
+DType fromNpDType(const py::dtype &npDType) {
+  switch (npDType.num()) {
+  case 0: // numpy.bool_
+    return DType::bool_;
+  case 2: // numpy.uint8
+    return DType::uint8;
+  case 1: // numpy.int8
+    return DType::int8;
+  case 3: // numpy.int16
+    return DType::int16;
+  case 5: // numpy.int32
+    return DType::int32;
+  case 7: // numpy.int64
+    return DType::int64;
+  case 23: // numpy.float16
+    return DType::float16;
+  case 11: // numpy.float32
+    return DType::float32;
+  case 12: // numpy.float64
+    return DType::float64;
+  case 14: // numpy.complex64
+    return DType::complex32;
+  case 15: // numpy.complex128
+    return DType::complex64;
+  default:
+    throw py::value_error(py::repr(npDType).operator std::string() +
+                          " unsupported");
+  }
+}
+
+void populateTorchDType(py::module &m) {
+  py::enum_<DType>(m, "dtype", py::arithmetic())
+      .value("uint8", DType::uint8)
+      .value("int8", DType::int8)
+      .value("int16", DType::int16)
+      .value("int32", DType::int32)
+      .value("int64", DType::int64)
+      .value("float16", DType::float16)
+      .value("float32", DType::float32)
+      .value("float64", DType::float64)
+      .value("complex32", DType::complex32)
+      .value("complex64", DType::complex64)
+      .value("bool", DType::bool_)
+      .value("qint8", DType::qint8)
+      .value("quint8", DType::quint8)
+      .value("bfloat16", DType::bfloat16)
+      .def(
+          "to_mlir_type",
+          [](DType &self, DefaultingPyMlirContext context) {
+            switch (self) {
+            case bool_:
+              // default is signless
+              return mlirIntegerTypeGet(context->get(), 1);
+            case uint8:
+              return mlirIntegerTypeUnsignedGet(context->get(), 8);
+            case int8:
+              return mlirIntegerTypeSignedGet(context->get(), 8);
+            case int16:
+              return mlirIntegerTypeSignedGet(context->get(), 16);
+            case int32:
+              return mlirIntegerTypeSignedGet(context->get(), 32);
+            case int64:
+              return mlirIntegerTypeSignedGet(context->get(), 64);
+            case float16:
+              return mlirF16TypeGet(context->get());
+            case float32:
+              return mlirF32TypeGet(context->get());
+            case float64:
+              return mlirF64TypeGet(context->get());
+            case complex32:
+              return mlirComplexTypeGet(mlirF32TypeGet(context->get()));
+            case complex64:
+              return mlirComplexTypeGet(mlirF64TypeGet(context->get()));
+            case bfloat16:
+              return mlirBF16TypeGet(context->get());
+            case qint8:
+            case quint8:
+              throw py::value_error("qint8, quint8 unsupported");
+            }
+          },
+          "context"_a = py::none())
+      .def(
+          "to_torch_value_type",
+          [](DType &self, DefaultingPyMlirContext context) -> py::object {
+            switch (self) {
+            case bool_:
+              return py::cast(PyTorch_BoolType(context));
+            case uint8:
+            case int8:
+            case int16:
+            case int32:
+            case int64:
+              return py::cast(PyTorch_IntType(context));
+            case float16:
+            case float32:
+            case float64:
+              return py::cast(PyTorch_FloatType(context));
+            case complex32:
+            case complex64:
+            case qint8:
+            case quint8:
+            case bfloat16:
+              throw py::value_error(
+                  py::repr(py::cast(self)).operator std::string() +
+                  " unsupported");
+            }
+          },
+          "context"_a = py::none())
+      .def_static(
+          "from_np_type",
+          [](const py::type &npType) { return fromNpDType(py::dtype(npType)); })
+      .def_static("from_np_type", fromNpDType)
+      .def("to_np_type",
+           [](DType &self) {
+             auto np = py::module::import("numpy");
+             switch (self) {
+             case bool_:
+               return np.attr("bool_");
+             case uint8:
+               return np.attr("uint8");
+             case int8:
+               return np.attr("int8");
+             case int16:
+               return np.attr("int16");
+             case int32:
+               return np.attr("int32");
+             case int64:
+               return np.attr("int64");
+             case float16:
+               return np.attr("float16");
+             case float32:
+               return np.attr("float32");
+             case float64:
+               return np.attr("float64");
+             case complex32:
+               return np.attr("complex64");
+             case complex64:
+               return np.attr("complex128");
+             case bfloat16:
+             case qint8:
+             case quint8:
+               throw py::value_error("bfloat16, qint8, quint8 unsupported");
+             }
+           })
+      .def("is_signless", [](DType &self) { return self == bool_; });
+}
+
+} // namespace mlir::torch

--- a/cpp_ext/TorchDType.h
+++ b/cpp_ext/TorchDType.h
@@ -1,0 +1,59 @@
+//
+// Created by maksim on 6/13/23.
+//
+
+#ifndef PI_TORCHDTYPE_H
+#define PI_TORCHDTYPE_H
+
+#include <type_traits>
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace mlir::torch {
+
+enum DType {
+  //  |-------------------|--------------------|
+  //  | Torch Type        | MLIR Type          |
+  //  |-------------------|--------------------|
+  //  | torch.bfloat16    | bf16               |
+  //  | torch.bool        | i1                 |
+  //  | torch.complex*    | complex<*>         |
+  //  | torch.float16     | f16                |
+  //  | torch.float32     | f32                |
+  //  | torch.float64     | f64                |
+  //  | torch.int16       | si16               |
+  //  | torch.int32       | si32               |
+  //  | torch.int64       | si64               |
+  //  | torch.int8        | si8                |
+  //  | torch.qint8       | !torch.qint8       |
+  //  | torch.quint8      | !torch.quint8      |
+  //  | torch.uint8       | ui8                |
+  //  |-------------------|--------------------|
+  uint8 = 0,
+  int8 = 1,
+  int16 = 2,
+  int32 = 3,
+  int64 = 4,
+  float16 = 5,
+  float32 = 6,
+  float64 = 7,
+  // complex_half 8
+  complex32 = 9,
+  complex64 = 10,
+  bool_ = 11,
+  qint8 = 12,
+  quint8 = 13,
+  // qint32 14
+  bfloat16 = 15
+};
+
+template <typename E> constexpr auto to_underlying(E e) noexcept {
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+
+void populateTorchDType(py::module &m);
+
+} // namespace mlir::torch
+#endif // PI_TORCHDTYPE_H

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "TorchValues.h"
+#include "TorchDType.h"
 #include "TorchTypes.h"
 
 #include <pybind11/pybind11.h>
@@ -163,10 +164,18 @@ void PyAnyTorchOptionalValue::bindDerived(ClassTy &c) {
   }
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Bool, bool)
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Device, int)
-DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Int, int)
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Float, float)
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(String, std::string)
 #undef DEFINE_OPTIONAL_BASE_CONCRETE_VALUE
+
+void PyAnyTorchOptionalIntValue::bindDerived(ClassTy &c) {
+  c.def(py::init<py::none>(), py::arg("value"));
+  c.def(py::init<int>(), py::arg("value"));
+  c.def(py::init<DType>(), py::arg("value"));
+  py::implicitly_convertible<py::none, PyAnyTorchOptionalIntValue>();
+  py::implicitly_convertible<int, PyAnyTorchOptionalIntValue>();
+  py::implicitly_convertible<DType, PyAnyTorchOptionalIntValue>();
+}
 
 void PyAnyTorchOptionalScalarValue::bindDerived(ClassTy &c) {
   c.def(py::init<py::none>(), py::arg("value"));
@@ -211,10 +220,23 @@ DEFINE_BIND_SCALAR_VALUE(Number)
   }
 DEFINE_BIND_SCALAR_VALUE(Bool, bool, bool, Bool)
 DEFINE_BIND_SCALAR_VALUE(Device, int, int, Integer)
-DEFINE_BIND_SCALAR_VALUE(Int, int, int, Integer)
 DEFINE_BIND_SCALAR_VALUE(Float, float, float, Float)
 DEFINE_BIND_SCALAR_VALUE(String, std::string, str, String)
 #undef DEFINE_BIND_SCALAR_VALUE
+
+void PyTorch_IntValue::bindDerived(ClassTy &c) {
+  c.def(py::init<int>(), py::arg("value"));
+  c.def(py::init<DType>(), py::arg("value"));
+  c.def("__int__", [](py::object &self) {
+    return py::module::import(MAKE_MLIR_PYTHON_QUALNAME("ir"))
+        .attr("IntegerAttr")(
+            self.attr("owner").attr("attributes").attr("__getitem__")("value"))
+        .attr("value")
+        .cast<int>();
+  });
+  py::implicitly_convertible<int, PyTorch_IntValue>();
+  py::implicitly_convertible<DType, PyTorch_IntValue>();
+}
 
 void PyTorch_DictValue::bindDerived(ClassTy &c) {}
 void PyTorch_TupleValue::bindDerived(ClassTy &c) {}

--- a/pi/mlir/__init__.py
+++ b/pi/mlir/__init__.py
@@ -90,7 +90,7 @@ from ._mlir_libs._pi_mlir import (
 )
 
 # noinspection PyUnresolvedReferences
-from ._mlir_libs._pi_mlir import Tensor
+from ._mlir_libs._pi_mlir import Tensor, dtype
 
 Tensor = Tensor
 

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -11,18 +11,15 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
-from . import Torch_BoolType, Torch_FloatType, Torch_IntType
+from . import Torch_BoolType, Torch_FloatType, Torch_IntType, dtype
 from .dialects import _torch_ops_gen as torch_dialect, torch as torch_dialect
 from .ir import (
-    BF16Type,
-    ComplexType,
     Context,
     DenseElementsAttr,
     DictAttr,
     F16Type,
     F32Type,
     F64Type,
-    FloatAttr,
     IndexType,
     InsertionPoint,
     IntegerAttr,
@@ -66,181 +63,6 @@ def mlir_mod_ctx(
                 yield module
 
 
-class dtype(Enum):
-    """
-    |-------------------|--------------------|
-    | Torch Type        | MLIR Type          |
-    |-------------------|--------------------|
-    | torch.bfloat16    | bf16               |
-    | torch.bool        | i1                 |
-    | torch.complex*    | complex<*>         |
-    | torch.float16     | f16                |
-    | torch.float32     | f32                |
-    | torch.float64     | f64                |
-    | torch.int16       | si16               |
-    | torch.int32       | si32               |
-    | torch.int64       | si64               |
-    | torch.int8        | si8                |
-    | torch.qint8       | !torch.qint8       |
-    | torch.quint8      | !torch.quint8      |
-    | torch.uint8       | ui8                |
-    |-------------------|--------------------|
-    """
-
-    uint8 = 0
-    int8 = 1
-    int16 = 2
-    int32 = 3
-    int64 = 4
-    float16 = 5
-    float32 = 6
-    float64 = 7
-    # complex_half 8
-    complex32 = 9
-    complex64 = 10
-    bool = 11
-    qint8 = 12
-    quint8 = 13
-    # qint32 14
-    bfloat16 = 15
-
-    # qint4x2 16
-    # qint2x4 17
-
-    def to_mlir_type(self):
-        match self:
-            case dtype.bfloat16:
-                return BF16Type.get()
-            case dtype.bool:
-                return IntegerType.get_signless(1)
-            case dtype.complex32:
-                return ComplexType.get(F32Type.get())
-            case dtype.complex64:
-                return ComplexType.get(F64Type.get())
-            case dtype.float16:
-                return F16Type.get()
-            case dtype.float32:
-                return F32Type.get()
-            case dtype.float64:
-                return F64Type.get()
-            case dtype.int8:
-                return IntegerType.get_signed(8)
-            case dtype.int16:
-                return IntegerType.get_signed(16)
-            case dtype.int32:
-                return IntegerType.get_signed(32)
-            case dtype.int64:
-                return IntegerType.get_signed(64)
-            case dtype.uint8:
-                return IntegerType.get_unsigned(8)
-            case _:
-                raise NotImplementedError(f"unimplemented to mlir_type from {self}")
-
-    def to_torch_value_type(self):
-        match self:
-            case dtype.bool:
-                return Torch_BoolType()
-            case dtype.float16 | dtype.float32 | dtype.float64:
-                return Torch_FloatType()
-            case dtype.int8 | dtype.int16 | dtype.int32 | dtype.int64 | dtype.uint8:
-                return Torch_IntType()
-            case _:
-                raise NotImplementedError(
-                    f"unimplemented to torch value type from {self}"
-                )
-
-    @staticmethod
-    def from_np_type(self):
-        match self:
-            case np.half:
-                return dtype.float16
-            case np.bool_:
-                return dtype.bool
-            case np.singlecomplex:
-                return dtype.complex32
-            case np.complex_:
-                return dtype.complex64
-            case np.float32:
-                return dtype.float32
-            case np.float64:
-                return dtype.float64
-            case np.int8:
-                return dtype.int8
-            case np.int16:
-                return dtype.int16
-            case np.int32:
-                return dtype.int32
-            case np.int64:
-                return dtype.int64
-            case np.uint8:
-                return dtype.uint8
-            case _:
-                raise NotImplementedError(f"unrecognized dtype: {self}")
-
-    def to_np_type(self):
-        match self:
-            case dtype.bfloat16 | dtype.float16:
-                return np.half
-            case dtype.bool:
-                return np.bool_
-            case dtype.complex32:
-                return np.singlecomplex
-            case dtype.complex64:
-                return np.complex_
-            case dtype.float32:
-                return np.float32
-            case dtype.float64:
-                return np.float64
-            case dtype.int8:
-                return np.int8
-            case dtype.int16:
-                return np.int16
-            case dtype.int32:
-                return np.int32
-            case dtype.int64:
-                return np.int64
-            case dtype.uint8:
-                return np.uint8
-            case _:
-                raise NotImplementedError(f"unrecognized dtype: {self}")
-
-    @staticmethod
-    def from_mlir_type(t: str):
-        match t:
-            case "bf16":
-                return dtype.bfloat16
-            case "i1":
-                return dtype.bool
-            case "complex32":
-                return dtype.complex32
-            case "complex64":
-                return dtype.complex64
-            case "f16":
-                return dtype.float16
-            case "f32":
-                return dtype.float32
-            case "f64":
-                return dtype.float64
-            case "si8":
-                return dtype.int8
-            case "si16":
-                return dtype.int16
-            case "si32":
-                return dtype.int32
-            case "si64":
-                return dtype.int64
-            case "ui8":
-                return dtype.uint8
-            case _:
-                raise NotImplementedError(f"Something's wrong with the internet {t}")
-
-    # IntegerType.get_signless(32) -> i32
-    # IntegerType.get_signed(32) -> si32
-    # IntegerType.get_unsigned(32) -> ui32
-    def is_signless(self):
-        return self in {dtype.bool}
-
-
 @register_attribute_builder("AnyI64Attr")
 def _anyI64Attr(x, context):
     return IntegerAttr.get(IntegerType.get_signless(64, context=context), x)
@@ -261,7 +83,7 @@ def infer_mlir_type(
     elif isinstance(py_val, float):
         return F64Type.get()
     elif isinstance(py_val, np.ndarray):
-        dtype = {
+        dtype_ = {
             np.int8: IntegerType.get_signless(8),
             np.int16: IntegerType.get_signless(16),
             np.int32: IntegerType.get_signless(32),
@@ -272,7 +94,7 @@ def infer_mlir_type(
             np.float32: F32Type.get(),
             np.float64: F64Type.get(),
         }[py_val.dtype.type]
-        return RankedTensorType.get(py_val.shape, dtype)
+        return RankedTensorType.get(py_val.shape, dtype_)
     else:
         raise NotImplementedError(
             f"Unsupported Python value {py_val=} with type {type(py_val)}"
@@ -286,7 +108,10 @@ def attr_from_numpy(arr: np.ndarray, dtype_: dtype = None):
     if dtype_ == dtype.bool:
         arr = np.packbits(arr, axis=None, bitorder="little")
     return DenseElementsAttr.get(
-        arr, signless=dtype_.is_signless(), type=dtype_.to_mlir_type(), shape=shape
+        arr,
+        signless=dtype_.is_signless(),
+        type=dtype_.to_mlir_type(),
+        shape=shape,
     )
 
 
@@ -343,9 +168,11 @@ class TensorPlaceholder:
         self.dtype = dtype_
 
     def to_value_tensor_type(self):
-        dtype = self.dtype.to_mlir_type()
+        dtype_ = self.dtype.to_mlir_type()
         # TODO(max): "modernize"
-        type = Type.parse(f"!torch.vtensor<[{','.join(map(str, self.shape))}],{dtype}>")
+        type = Type.parse(
+            f"!torch.vtensor<[{','.join(map(str, self.shape))}],{dtype_}>"
+        )
         return type
 
     def to_nonvalue_tensor_type(self):
@@ -357,12 +184,12 @@ class TensorPlaceholder:
         type_attr = TypeAttr.get(self.to_value_tensor_type())
         return DictAttr.get({"torch.type_bound": type_attr})
 
-    def to(self, dtype: dtype):
-        self.dtype = dtype
+    def to(self, dtype_: dtype):
+        self.dtype = dtype_
         return self
 
-    def type(self, dtype):
-        return self.to(dtype)
+    def type(self, dtype_):
+        return self.to(dtype_)
 
     def bool(self):
         return self.to(dtype.bool)


### PR DESCRIPTION
This fixes errors like this:

```
mean(): incompatible function arguments. The following argument types are supported:
    1. (self: Tensor, dim: AnyTorchOptionalListOfTorchIntValue = None, keepdim: Torch_BoolValue = False, dtype: AnyTorchOptionalIntValue = None) -> Tensor
    2. (self: Tensor, dtype: AnyTorchOptionalIntValue = None) -> Tensor

Invoked with: <Tensor object at 0x7f94668dcc30>, (0,); kwargs: dtype=<dtype.float32: 6>
```

where the issue is that you've passed `dtype=<dtype.float32: 6>`, something that should/could be cast[^1] to `AnyTorchOptionalIntValue` but the plumbing isn't there. 

In order to make this work you need 

1. Make pybind11 familiar/recognize/handle `dtype` objects.
2. Implement conversion from `dtype` -> `AnyTorchOptionalIntValue`.

To make (**1**) happen you do the standard thing - implement a C++ class/struct/enum and then bind/expose it to python (hence the addition/transition of/to `TorchDType.cpp/h`). For `dtype` that was easy because it was already implemented as a python class (so the logic was already worked out), it just had to be moved into C++.

To make (**2**) happen you add constructors to the various things that should be able to be constructed from a `dtype/DType`, starting with `PyTorch_IntValue(DType b)`. Then `PyAnyTorchOptionalIntValue` comes for free.

One important thing to understand about `dtype/DType` - these are passed around at various places in PyTorch APIs but they are not actually modeled by the formal torch-mlir type system. So none of the torch-mlir op signatures talk about a `dtype/DType` as a type but they have plenty of references to `dtype` [as an int](https://github.com/llvm/torch-mlir/blob/7c6961bcbf75811c21c026b31e2fe3eb67099cb9/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td#L3804).

Et voila this gets us to `PASS=644` (i.e. +~40)

Note, there are a couple of low-hanging fruits like this remaining (`memory_format` and `layout`) that are similar fixes.

[^1]: Just semantically reasonable - an optional is either `None` or that thing, and `dtype`s generally can be cast to some `int` kind of thing.