### PR TITLE
xfail `ElementwiseGeFloatScalarModule_basic`

### DIFF
--- a/cpp_ext/TorchDType.cpp
+++ b/cpp_ext/TorchDType.cpp
@@ -15,6 +15,7 @@
 
 namespace py = pybind11;
 using namespace mlir::python;
+using namespace py::literals;
 
 namespace mlir::torch {
 

--- a/tests/torch_mlir/xfail.py
+++ b/tests/torch_mlir/xfail.py
@@ -1,4 +1,4 @@
-PI_XFAIL_SET = {
+CRASHING = {
     "ArangeNegativeStartIntModule_basic",
     "ArangeStartNegativeStepIntModule_basic",
     "Aten_EmbeddingBagExample_basic",
@@ -15,3 +15,5 @@ PI_XFAIL_SET = {
     "SliceCopyStartGreaterThanDimSize_Module_basic",
     "UniformModule_basic",
 }
+
+PI_XFAIL_SET = {"ElementwiseGeFloatScalarModule_basic"}


### PR DESCRIPTION
xfail `ElementwiseGeFloatScalarModule_basic` because upstream spuriously casts to f64:

```mlir
   func.func @forward(%arg0: tensor<?x?xf32>) -> tensor<?x?xi1> {
     %c1 = arith.constant 1 : index
     %c0 = arith.constant 0 : index
-    %cst = arith.constant 6.000000e-01 : f32
+    %cst = arith.constant 6.000000e-01 : f64
     %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %dim_0 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
     %0 = tensor.empty(%dim, %dim_0) : tensor<?x?xi1>
     %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x?xf32>) outs(%0 : tensor<?x?xi1>) {
     ^bb0(%in: f32, %out: i1):
-      %2 = arith.cmpf uge, %in, %cst : f32
-      linalg.yield %2 : i1
+      %2 = arith.truncf %cst : f64 to f32
+      %3 = arith.cmpf uge, %in, %2 : f32
+      linalg.yield %3 : i1
     } -> tensor<?x?xi1>
     return %1 : tensor<?x?xi1>
   }
```