### PR TITLE
Implement torch.Tensor.to(dtype) and torch.device(str)

### DIFF
--- a/cpp_ext/TorchOps.cpp
+++ b/cpp_ext/TorchOps.cpp
@@ -92,6 +92,11 @@ PyAnyTorchTensorValue view(PyAnyTorchTensorValue &self, const py::args &args) {
   return view(self, size);
 }
 
+// prim::device : (str) -> (Device)
+PyTorch_DeviceValue device(std::string &type) {
+  return PyGlobals::get().lookupOperationClass("torch.constant.device").value()(type).cast<PyTorch_DeviceValue>();
+}
+
 void populateTorchMLIROps(py::module &m) {
 
   py::register_exception_translator([](std::exception_ptr p) {
@@ -137,6 +142,13 @@ void populateTorchMLIROps(py::module &m) {
       [](PyAnyTorchTensorValue &self, const py::args &args)
           -> PyAnyTorchTensorValue { return view(self, args); },
       "size"_a);
+
+  // prim::device : (str) -> (Device)
+  m.def(
+      "device",
+      [](std::string type)
+          -> PyTorch_DeviceValue { return device(type); },
+      "type"_a);
 
 }
 

--- a/cpp_ext/TorchTensor.cpp
+++ b/cpp_ext/TorchTensor.cpp
@@ -230,6 +230,18 @@ void PyAnyTorchTensorValue::bindDerived(ClassTy &c) {
     return view(self, args);
   });
 
+  // aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)
+  c.def(
+      "to",
+      [](const PyAnyTorchTensorValue &self, const PyTorch_IntValue &dtype,
+         const PyTorch_BoolValue &non_blocking, const PyTorch_BoolValue &copy,
+         const PyAnyTorchOptionalIntValue &memory_format)
+          -> PyAnyTorchTensorValue {
+        return to(self, dtype, non_blocking, copy, memory_format);
+      },
+      "dtype"_a = py::none(), "non_blocking"_a = false, "copy"_a = false,
+      "memory_format"_a = py::none());
+
 #include "TorchTensor.pybinds.cpp"
 }
 

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -163,7 +163,7 @@ void PyAnyTorchOptionalValue::bindDerived(ClassTy &c) {
                                PyAnyTorchOptional##TORCHTYPE##Value>();        \
   }
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Bool, bool)
-DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Device, int)
+DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Device, std::string)
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(Float, float)
 DEFINE_OPTIONAL_BASE_CONCRETE_VALUE(String, std::string)
 #undef DEFINE_OPTIONAL_BASE_CONCRETE_VALUE
@@ -219,7 +219,7 @@ DEFINE_BIND_SCALAR_VALUE(Number)
     py::implicitly_convertible<CPPTYPE, PyTorch_##TORCHTYPE##Value>();         \
   }
 DEFINE_BIND_SCALAR_VALUE(Bool, bool, bool, Bool)
-DEFINE_BIND_SCALAR_VALUE(Device, int, int, Integer)
+DEFINE_BIND_SCALAR_VALUE(Device, std::string, str, String)
 DEFINE_BIND_SCALAR_VALUE(Float, float, float, Float)
 DEFINE_BIND_SCALAR_VALUE(String, std::string, str, String)
 #undef DEFINE_BIND_SCALAR_VALUE

--- a/cpp_ext/TorchValues.h
+++ b/cpp_ext/TorchValues.h
@@ -136,7 +136,7 @@ public:
                       .cast<PyTorch_##TORCHTYPE##Value>()) {}                  \
   };
 DECLARE_SCALAR_VALUE(Bool, bool, bool)
-DECLARE_SCALAR_VALUE(Device, int, device)
+DECLARE_SCALAR_VALUE(Device, std::string, device)
 DECLARE_SCALAR_VALUE(Float, float, float)
 DECLARE_SCALAR_VALUE(String, std::string, str)
 #undef DECLARE_SCALAR_VALUE
@@ -300,7 +300,7 @@ public:
   };
 
 DECLARE_OPTIONAL_BASE_CONCRETE_VALUE(Bool, bool)
-DECLARE_OPTIONAL_BASE_CONCRETE_VALUE(Device, int)
+DECLARE_OPTIONAL_BASE_CONCRETE_VALUE(Device, std::string)
 DECLARE_OPTIONAL_BASE_CONCRETE_VALUE(Float, float)
 DECLARE_OPTIONAL_BASE_CONCRETE_VALUE(String, std::string)
 #undef DECLARE_OPTIONAL_BASE_CONCRETE_VALUE


### PR DESCRIPTION
As of this commit, we are at 668/929 e2e suite tests, this PR binds an overloaded signature to the PyTorchTensorValue class that allows for syntax such as 
```
x.to(torch.float32)
```
plus keyword arguments.

Additionally implements torch.device, which takes a constant string value and constructs a torch.constant.device which that value as an attribute. There is a question about something like torch.device('cuda',0) but it does not seem to appear in the e2e test suite, and the operation definition via torch_ops_gen does not seem to accept an index attribute:

```
@_ods_cext.register_operation(_Dialect)
@_ods_extend_opview_class(_ods_ext_module)
class ConstantDeviceOp(_ods_ir.OpView):
  OPERATION_NAME = "torch.constant.device"

  _ODS_REGIONS = (0, True)

  def __init__(self, value, *, loc=None, ip=None):
    operands = []
    results = []
    attributes = {}
    regions = None
    _ods_context = _ods_get_default_loc_context(loc)
    attributes["value"] = (value if (
    issubclass(type(value), _ods_ir.Attribute) or
    not _ods_ir.AttrBuilder.contains('StrAttr')) else
      _ods_ir.AttrBuilder.get('StrAttr')(value, context=_ods_context))
    results = _ods_ir.InferTypeOpInterface(ConstantDeviceOp).inferReturnTypes(
        operands=operands,
        attributes=_ods_ir.DictAttr.get(attributes, context=_ods_context),
        context=_ods_context,
        loc=loc)
    _ods_successors = None
    super().__init__(self.build_generic(
      attributes=attributes, results=results, operands=operands,
      successors=_ods_successors, regions=regions, loc=loc, ip=ip))

      
      ...
```