### PR TITLE
Irrelevant unexpected kwargs

### DIFF
--- a/pi/__init__.py
+++ b/pi/__init__.py
@@ -29,7 +29,6 @@ from .mlir.utils import (
     rand,
     randn,
     tensor,
-    zeros_like,
     empty_like,
     TensorPlaceholder,
     memory_format,

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -151,7 +151,6 @@ zeros = functools.partial(_np_wrapper, factory=create_zeros)
 rand = functools.partial(_np_wrapper, factory=np.random.rand)
 randn = functools.partial(_np_wrapper, factory=np.random.randn)
 tensor = functools.partial(_np_wrapper, factory=np.array)
-zeros_like = functools.partial(_np_wrapper, factory=np.zeros_like)
 empty_like = functools.partial(_np_wrapper, factory=np.empty_like)
 
 class layout(Enum):

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -132,6 +132,9 @@ def _np_wrapper(*args, factory=None, **kwargs):
         kwargs.pop("device")
     if "dtype" in kwargs and isinstance(kwargs["dtype"], dtype):
         kwargs["dtype"] = kwargs["dtype"].to_np_type()
+    if "pin_memory" in kwargs:
+        kwargs.pop("pin_memory")
+
     return torch_dialect.NonValueTensorLiteralOp(factory(*args, **kwargs))
 
 def create_zeros(*args, **kwargs):
@@ -150,7 +153,6 @@ randn = functools.partial(_np_wrapper, factory=np.random.randn)
 tensor = functools.partial(_np_wrapper, factory=np.array)
 zeros_like = functools.partial(_np_wrapper, factory=np.zeros_like)
 empty_like = functools.partial(_np_wrapper, factory=np.empty_like)
-
 
 class layout(Enum):
     strided = 1


### PR DESCRIPTION
As of this commit, we are at 672/929 e2e suite tests. 
This PR addresses unexpected kwargs from torch, which np_wrapper cannot take in. 

One is "pin_memory" from "empty_like" func. If such is in kwargs, np wrapper simply pops it. 
Another is "zeros_like" from torch passing on tensor object when kwargs is default (None). 
For this problem, instead of using np wrapper, we directly called zeros_like from TorchOps by removing zeros like from __init__,py and from utils. 