### PR TITLE
Miscellanous API Compat Fixes

### DIFF
--- a/cpp_ext/TorchOps.cpp
+++ b/cpp_ext/TorchOps.cpp
@@ -97,6 +97,11 @@ PyTorch_DeviceValue device(std::string &type) {
   return PyGlobals::get().lookupOperationClass("torch.constant.device").value()(type).cast<PyTorch_DeviceValue>();
 }
 
+// aten::mean.dim : (Tensor, int?, bool, int?) -> (Tensor)
+PyAnyTorchTensorValue mean(const PyAnyTorchTensorValue &self, const PyAnyTorchOptionalIntValue &dim, const PyTorch_BoolValue &keepdim, const PyAnyTorchOptionalIntValue &dtype) {
+  return PyGlobals::get().lookupOperationClass("torch.aten.mean.dim").value()(PyAnyTorchTensorType::getWithLeastStaticInformation(DefaultingPyMlirContext::resolve()), self, dim, keepdim, dtype).cast<PyAnyTorchTensorValue>();
+}
+
 void populateTorchMLIROps(py::module &m) {
 
   py::register_exception_translator([](std::exception_ptr p) {
@@ -150,6 +155,17 @@ void populateTorchMLIROps(py::module &m) {
           -> PyTorch_DeviceValue { return device(type); },
       "type"_a);
 
+  // aten::mean.dim : (Tensor, int?, bool, int?) -> (Tensor)
+  m.def(
+      "mean",
+      [](const PyAnyTorchTensorValue &self,
+         const PyAnyTorchOptionalIntValue &dim,
+         const PyTorch_BoolValue &keepdim,
+         const PyAnyTorchOptionalIntValue &dtype) -> PyAnyTorchTensorValue {
+        return mean(self, dim, keepdim, dtype);
+      },
+      "self"_a, "dim"_a = py::none(), "keepdim"_a = false,
+      "dtype"_a = py::none());
 }
 
 } // namespace mlir::torch

--- a/cpp_ext/TorchTensor.cpp
+++ b/cpp_ext/TorchTensor.cpp
@@ -210,6 +210,12 @@ void PyAnyTorchTensorValue::bindDerived(ClassTy &c) {
           -> PyAnyTorchTensorValue { return add(self, other, 1.0f); },
       "other"_a);
 
+  c.def(
+      "__sub__",
+      [](const PyAnyTorchTensorValue &self, const PyAnyTorchTensorValue &other)
+          -> PyAnyTorchTensorValue { return sub(self, other, 1.0f); },
+      "other"_a);
+
   // @overload view(self, dtype _dtype) -> Tensor
   c.def("view",
         [](const PyAnyTorchTensorValue &self, const PyTorch_IntValue &dtype) {

--- a/cpp_ext/TorchTypes.h
+++ b/cpp_ext/TorchTypes.h
@@ -103,6 +103,12 @@ public:
   _(TorchInt)                                                                  \
   _(TorchString)
 
+#define FORALL_LIST_BASE_CONCRETE_TYPES_WITH_TYPE(_)                                                      \
+  _(TorchBool, Bool)                                                           \
+  _(TorchFloat, Float)                                                         \
+  _(TorchInt, Int)                                                             \
+  _(TorchString, String)
+
 #define DECLARE_LIST_BASE_CONCRETE_TYPE(CONCRETETYPE)                          \
   class PyAnyTorchListOf##CONCRETETYPE##Type                                   \
       : public PyConcreteType<PyAnyTorchListOf##CONCRETETYPE##Type,            \

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -192,8 +192,8 @@ class TensorPlaceholder:
         type_attr = TypeAttr.get(self.to_value_tensor_type())
         return DictAttr.get({"torch.type_bound": type_attr})
 
-    def to(self, dtype_: dtype):
-        self.dtype = dtype_
+    def to(self, dtype: dtype):
+        self.dtype = dtype
         return self
 
     def type(self, dtype_):

--- a/tests/unit/test_mlir_values.py
+++ b/tests/unit/test_mlir_values.py
@@ -135,6 +135,64 @@ class TestTorchValues:
                 tnone,
             )
 
+    def test_int_value_arithmetic(self):
+        with mlir_mod_ctx():
+            x = torch.ConstantIntOp(2)
+            y = torch.ConstantIntOp(3)
+
+            v = x + y
+            check_correct(
+                "Torch_IntValue(%0 = torch.aten.add.int %int2, %int3 : !torch.int, !torch.int -> !torch.int)",
+                v,
+            )
+
+            v = x - y
+            check_correct(
+                "Torch_IntValue(%1 = torch.aten.sub.int %int2, %int3 : !torch.int, !torch.int -> !torch.int)",
+                v,
+            )
+
+            v = x * y
+            check_correct(
+                "Torch_IntValue(%2 = torch.aten.mul.int %int2, %int3 : !torch.int, !torch.int -> !torch.int)",
+                v,
+            )
+
+            v = x / y
+            check_correct(
+                "Torch_FloatValue(%3 = torch.aten.div.int %int2, %int3 : !torch.int, !torch.int -> !torch.float)",
+                v,
+            )
+
+            v = x // y
+            check_correct(
+                "Torch_IntValue(%4 = torch.aten.floordiv.int %int2, %int3 : !torch.int, !torch.int -> !torch.int)",
+                v,
+            )
+
+    def test_float_value_arithmetic(self):
+        with mlir_mod_ctx():
+            x = torch.ConstantFloatOp(2)
+            y = torch.ConstantFloatOp(3)
+
+            v = x - y
+            check_correct(
+                "Torch_FloatValue(%0 = torch.aten.sub.float %float2.000000e00, %float3.000000e00 : !torch.float, !torch.float -> !torch.float)",
+                v,
+            )
+
+            v = x * y
+            check_correct(
+                "Torch_FloatValue(%1 = torch.aten.mul.float %float2.000000e00, %float3.000000e00 : !torch.float, !torch.float -> !torch.float)",
+                v,
+            )
+
+            v = x / y
+            check_correct(
+                "Torch_FloatValue(%2 = torch.aten.div.float %float2.000000e00, %float3.000000e00 : !torch.float, !torch.float -> !torch.float)",
+                v,
+            )
+
     def test_agg_values(self):
         with mlir_mod_ctx():
             tint = Torch_IntType.get()
@@ -504,4 +562,34 @@ class TestTorchValues:
             check_correct(
                 "%1 = torch.aten.unbind.int %0, %int1 : !torch.tensor<[2,2],f64>, !torch.int -> !torch.list<tensor>",
                 r.owner,
+            )
+
+    def test_ListIndexing(self):
+        with mlir_mod_ctx():
+            l = AnyTorchListOfTorchIntValue([1,2,3])
+            t = l[0]
+            check_correct(
+                "Torch_IntValue(%1 = torch.aten.__getitem__.t %0, %int0 : !torch.list<int>, !torch.int -> !torch.int)",
+                t,
+            )
+
+            l = AnyTorchListOfTorchFloatValue([1.0, 2.0, 3.0])
+            t = l[0]
+            check_correct(
+                "Torch_FloatValue(%3 = torch.aten.__getitem__.t %2, %int0 : !torch.list<float>, !torch.int -> !torch.float)",
+                t,
+            )
+
+            l = AnyTorchListOfTorchBoolValue([True, False, True])
+            t = l[0]
+            check_correct(
+                "Torch_BoolValue(%5 = torch.aten.__getitem__.t %4, %int0 : !torch.list<bool>, !torch.int -> !torch.bool)",
+                t,
+            )
+
+            l = AnyTorchListOfTorchStringValue(["1.0", "2.0", "3"])
+            t = l[0]
+            check_correct(
+                "Torch_StringValue(%7 = torch.aten.__getitem__.t %6, %int0 : !torch.list<str>, !torch.int -> !torch.str)",
+                t,
             )


### PR DESCRIPTION
This PR focused on chasing down [this test](https://github.com/llvm/torch-mlir/blob/4fd4477e15a2726724d7cf18cb44421ba209da3a/python/torch_mlir_e2e_test/test_suite/rng.py#L94) which consequently involved a lot of unimplemented operations - since the PR is getting large but it does increment the number of passing tests, I'm committing now and will resolve the rest of the operations later. This PR contributes the following:

- Allow TensorPlaceholder.to to accept a 'dtype' kwarg (this two character change passes another 8 tests)
- Allow pi.mean() to accept a scalar dim argument as opposed to only allowing lists of integers
- Implement the subtraction operator (`__sub__`) between TensorValues
- Implement the indexing operator for typed lists (`__getitem__`) + unit tests
- Implement arithmetic operators for int and float values + unit tests

One note: for some reason, I could not find any floating point addition operation in `_torch_ops_gen.py` to bind floating point arithmetic to, therefore it remains unimplemented. There is float_int addition but I couldn't find any operation specific to floats - I'd expect some sort of signature like `torch.aten.add.float` but it doesn't seem that any are present there. If you know of such an operation - I'll add it to this PR. Similarly with floored division for floats.