### PR TITLE
add formatter workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,29 @@
+name: Format Code
+
+on: [push, pull_request]
+
+jobs:
+  python-black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "-t py311 --check --diff --color"
+          src: "./pi/mlir"
+
+      - uses: psf/black@stable
+        with:
+          options: "-t py311 --check --diff --color"
+          src: "./tests/unit"
+
+  cpp-clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: '16'
+          check-path: 'cpp_ext'
+          exclude-regex: '(inc|impls|pybinds)'

--- a/cpp_ext/TorchOps.cpp
+++ b/cpp_ext/TorchOps.cpp
@@ -94,12 +94,23 @@ PyAnyTorchTensorValue view(PyAnyTorchTensorValue &self, const py::args &args) {
 
 // prim::device : (str) -> (Device)
 PyTorch_DeviceValue device(std::string &type) {
-  return PyGlobals::get().lookupOperationClass("torch.constant.device").value()(type).cast<PyTorch_DeviceValue>();
+  return PyGlobals::get()
+      .lookupOperationClass("torch.constant.device")
+      .value()(type)
+      .cast<PyTorch_DeviceValue>();
 }
 
 // aten::mean.dim : (Tensor, int?, bool, int?) -> (Tensor)
-PyAnyTorchTensorValue mean(const PyAnyTorchTensorValue &self, const PyAnyTorchOptionalIntValue &dim, const PyTorch_BoolValue &keepdim, const PyAnyTorchOptionalIntValue &dtype) {
-  return PyGlobals::get().lookupOperationClass("torch.aten.mean.dim").value()(PyAnyTorchTensorType::getWithLeastStaticInformation(DefaultingPyMlirContext::resolve()), self, dim, keepdim, dtype).cast<PyAnyTorchTensorValue>();
+PyAnyTorchTensorValue mean(const PyAnyTorchTensorValue &self,
+                           const PyAnyTorchOptionalIntValue &dim,
+                           const PyTorch_BoolValue &keepdim,
+                           const PyAnyTorchOptionalIntValue &dtype) {
+  return PyGlobals::get()
+      .lookupOperationClass("torch.aten.mean.dim")
+      .value()(PyAnyTorchTensorType::getWithLeastStaticInformation(
+                   DefaultingPyMlirContext::resolve()),
+               self, dim, keepdim, dtype)
+      .cast<PyAnyTorchTensorValue>();
 }
 
 void populateTorchMLIROps(py::module &m) {
@@ -151,8 +162,7 @@ void populateTorchMLIROps(py::module &m) {
   // prim::device : (str) -> (Device)
   m.def(
       "device",
-      [](std::string type)
-          -> PyTorch_DeviceValue { return device(type); },
+      [](std::string type) -> PyTorch_DeviceValue { return device(type); },
       "type"_a);
 
   // aten::mean.dim : (Tensor, int?, bool, int?) -> (Tensor)

--- a/cpp_ext/TorchTypes.h
+++ b/cpp_ext/TorchTypes.h
@@ -103,7 +103,7 @@ public:
   _(TorchInt)                                                                  \
   _(TorchString)
 
-#define FORALL_LIST_BASE_CONCRETE_TYPES_WITH_TYPE(_)                                                      \
+#define FORALL_LIST_BASE_CONCRETE_TYPES_WITH_TYPE(_)                           \
   _(TorchBool, Bool)                                                           \
   _(TorchFloat, Float)                                                         \
   _(TorchInt, Int)                                                             \

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -4,8 +4,8 @@
 
 #include "TorchValues.h"
 #include "TorchDType.h"
-#include "TorchTypes.h"
 #include "TorchOps.h"
+#include "TorchTypes.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>

--- a/pi/mlir/compile.py
+++ b/pi/mlir/compile.py
@@ -2,23 +2,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
-import contextlib
+import os
 import re
+import sys
+import tempfile
 import warnings
 from collections import OrderedDict
 from io import StringIO
-import os
-import sys
-import tempfile
 from itertools import chain
 
-from .dialects import _torch_ops_gen as torch_dialect
-from .dialects import torch as torch_dialect, func as func_dialect
 from . import ir
+from .dialects import func as func_dialect, torch as torch_dialect
 from .passmanager import PassManager
 from .utils import disable_multithreading
-
-from .. import nn, Tensor
+from .. import Tensor, nn
 
 
 def get_module_name_for_debug_dump(module):
@@ -139,7 +136,6 @@ def pipile(pi_module: nn.Module, example_args=None, module_name="pi.module_name"
         pi_module.__class__.__name__
     )
     with ir.InsertionPoint(mlir_module.body):
-
         placeholders = pi_module.forward.__dict__.get("__placeholders__")
         if placeholders:
             assert isinstance(placeholders, OrderedDict)

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -137,6 +137,7 @@ def _np_wrapper(*args, factory=None, **kwargs):
 
     return torch_dialect.NonValueTensorLiteralOp(factory(*args, **kwargs))
 
+
 def create_zeros(*args, **kwargs):
     if len(args) == 1 and isinstance(args[0], (list, tuple)):
         # Input is a list or tuple
@@ -145,6 +146,7 @@ def create_zeros(*args, **kwargs):
         # Input is a sequence of ints along with kwargs
         return np.zeros(args, **kwargs)
 
+
 empty = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=np.ones)
 zeros = functools.partial(_np_wrapper, factory=create_zeros)
@@ -152,6 +154,7 @@ rand = functools.partial(_np_wrapper, factory=np.random.rand)
 randn = functools.partial(_np_wrapper, factory=np.random.randn)
 tensor = functools.partial(_np_wrapper, factory=np.array)
 empty_like = functools.partial(_np_wrapper, factory=np.empty_like)
+
 
 class layout(Enum):
     strided = 1

--- a/tests/torch_mlir/xfail.py
+++ b/tests/torch_mlir/xfail.py
@@ -32,5 +32,5 @@ PI_XFAIL_SET = {
     "Threshold3dFloatModule_basic",
     "ThresholdBackward3dFloatModule_basic",
     "TypePromotionAlphaWiderModule_basic",
-    "TypePromotionSameCategoryZeroRankWider_basic"
+    "TypePromotionSameCategoryZeroRankWider_basic",
 }

--- a/tests/unit/test_mlir_values.py
+++ b/tests/unit/test_mlir_values.py
@@ -505,7 +505,6 @@ class TestTorchValues:
 
     def test_AnyTorchListOfOptionalTensorValue(self):
         with mlir_mod_ctx():
-
             t = torch.NonValueTensorLiteralOp(_elementsAttr(np.ones((2, 2))))
             l = AnyTorchListOfOptionalTensorValue([t, t])
             check_correct(
@@ -566,7 +565,7 @@ class TestTorchValues:
 
     def test_ListIndexing(self):
         with mlir_mod_ctx():
-            l = AnyTorchListOfTorchIntValue([1,2,3])
+            l = AnyTorchListOfTorchIntValue([1, 2, 3])
             t = l[0]
             check_correct(
                 "Torch_IntValue(%1 = torch.aten.__getitem__.t %0, %int0 : !torch.list<int>, !torch.int -> !torch.int)",

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -5,7 +5,9 @@ from textwrap import dedent
 
 def check_correct(correct, op):
     correct = dedent(
-        re.sub(r"([%#@]\w+)|(\^bb\d+)|(0x\w+)|dense<.*?>", "%DONT_CARE", correct.strip())
+        re.sub(
+            r"([%#@]\w+)|(\^bb\d+)|(0x\w+)|dense<.*?>", "%DONT_CARE", correct.strip()
+        )
     )
     op = dedent(
         re.sub(r"([%#@]\w+)|(\^bb\d+)|(0x\w+)|dense<.*?>", "%DONT_CARE", str(op))


### PR DESCRIPTION
Let's start making sure to use `black` to format python code and `clang-format` to format cpp. 