### PR TITLE
remove calls through python interp to get attr values

### DIFF
--- a/tests/unit/test_mlir_values.py
+++ b/tests/unit/test_mlir_values.py
@@ -387,7 +387,7 @@ class TestTorchValues:
                 NumToTensor(): incompatible function arguments. The following argument types are supported:
                     1. (a: pi.mlir._mlir_libs._pi_mlir.AnyTorchScalarValue, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.Tensor
                     
-                Invoked with: <pi.mlir._mlir_libs._pi_mlir.Torch_NonValueTensorValue object at 0x1153a9cf0>
+                Invoked with: Torch_NonValueTensorValue(%2 = torch.tensor.literal(dense<1.000000e+00> : tensor<2x2xf64>) : !torch.tensor<[2,2],f64>)
                 """
                     ),
                     e,
@@ -436,7 +436,7 @@ class TestTorchValues:
                             5. (a: pi.mlir._mlir_libs._pi_mlir.AnyTorchListValue, b: pi.mlir._mlir_libs._pi_mlir.AnyTorchListValue, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.AnyTorchListValue
                             6. (self: pi.mlir._mlir_libs._pi_mlir.Tensor, other: pi.mlir._mlir_libs._pi_mlir.Tensor, alpha: pi.mlir._mlir_libs._pi_mlir.AnyTorchScalarValue = 1, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.Tensor
                             7. (lhs: pi.mlir._mlir_libs._pi_mlir.AnyTorchScalarValue, rhs: pi.mlir._mlir_libs._pi_mlir.AnyTorchScalarValue, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.AnyTorchScalarValue
-                        Invoked with: <pi.mlir._mlir_libs._pi_mlir.Torch_FloatValue object at 0x111f7e870>, <pi.mlir._mlir_libs._pi_mlir.Torch_FloatValue object at 0x111f7e870>, <pi.mlir._mlir_libs._pi_mlir.Torch_FloatValue object at 0x111f7e870>
+                        Invoked with: Torch_FloatValue(%6 = torch.aten.Float.Scalar %int1 : !torch.int -> !torch.float), Torch_FloatValue(%6 = torch.aten.Float.Scalar %int1 : !torch.int -> !torch.float), Torch_FloatValue(%6 = torch.aten.Float.Scalar %int1 : !torch.int -> !torch.float)
                         """
                             ).splitlines(keepends=False)
                         )
@@ -581,9 +581,7 @@ class TestTorchValues:
 
             l = AnyTorchListOfTorchStringValue(["1.0", "2.0", "3"])
             t = l[0]
-            # check_correct(
-            #     "Torch_StringValue(%7 = torch.aten.__getitem__.t %6, %int0 : !torch.list<str>, !torch.int -> !torch.str)",
-            #     t,
-            # )
-
-        print(module.operation.verify())
+            check_correct(
+                "Torch_StringValue(%7 = torch.aten.__getitem__.t %6, %int0 : !torch.list<str>, !torch.int -> !torch.str)",
+                t,
+            )

--- a/tests/unit/test_tensor.py
+++ b/tests/unit/test_tensor.py
@@ -57,7 +57,7 @@ class TestOverloadCast:
 
     def test_optional_args(self):
         with mlir_mod_ctx():
-            ttt = tensor_op(np.random.randint(0, 10, (10, 10)))
+            ttt = tensor_op(5 * np.ones((10, 10)).astype(int))
             r = ttt.argmax(keepdim=bool_op(False))
             check_correct(
                 "Tensor(%5 = torch.aten.argmax %4, %none, %false : !torch.tensor<[10,10],si64>, !torch.none, !torch.bool -> !torch.tensor)",
@@ -72,7 +72,7 @@ class TestOverloadCast:
                         argmax(): incompatible function arguments. The following argument types are supported:
                             1. (self: pi.mlir._mlir_libs._pi_mlir.Tensor, dim: pi.mlir._mlir_libs._pi_mlir.AnyTorchOptionalIntValue = None, keepdim: pi.mlir._mlir_libs._pi_mlir.Torch_BoolValue = False, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.Tensor
 
-                        Invoked with: <pi.mlir._mlir_libs._pi_mlir.Tensor object at %DONT_CARE>, <pi.mlir._mlir_libs._pi_mlir.Torch_BoolValue object at %DONT_CARE>
+                        Invoked with: Tensor(%0 = torch.tensor.literal(dense<5> : tensor<10x10xsi64>) : !torch.tensor<[10,10],si64>), Torch_BoolValue(%false_0 = torch.constant.bool false)
                         """
                     ),
                     str(e),
@@ -88,7 +88,7 @@ class TestOverloadCast:
                         argmax(): incompatible function arguments. The following argument types are supported:
                             1. (self: pi.mlir._mlir_libs._pi_mlir.Tensor, dim: pi.mlir._mlir_libs._pi_mlir.AnyTorchOptionalIntValue = None, *, keepdim: pi.mlir._mlir_libs._pi_mlir.Torch_BoolValue = False) -> object
 
-                        Invoked with: <pi.mlir._mlir_libs._pi_mlir.Tensor object at %DONT_CARE>, None, <pi.mlir._mlir_libs._pi_mlir.Torch_BoolValue object at %DONT_CARE>
+                        Invoked with: Tensor(%DONT_CARE = torch.tensor.literal(%DONT_CARE : tensor<1%DONT_CARE>) : !torch.tensor<[3,3],si64>), Torch_BoolValue(%DONT_CARE = torch.constant.bool false)
                         """
                     ),
                     str(e),


### PR DESCRIPTION
This PR removes the last bit of routing through the python interpreter (get `torch.constant.*` attribute values) and instead goes through the MLIR CAPI. 

Note, it uses a function with signature `template <typename T> auto getAttributeValue(const T &value)` uses some "advanced" cpp language features so I'll explain a little:

```cpp
template <typename T> auto getAttributeValue(const T &value) {
  if constexpr (std::is_same<T, PyTorch_BoolValue>::value)
    return mlirBoolAttrGetValue(attr);
  else if constexpr (std::is_same<T, PyTorch_FloatValue>::value)
    return mlirFloatAttrGetValueDouble(attr);
  ...
}
```

1. `template <typename T> ` this is a generic/template function with template parameter `T` [^1] - this function is generic across the different `PyTorch_*` types;
2. `auto` in return type position lets/tells the compiler to infer the return type "automatically";
3. `if constexpr` is a conditional that's evaluated at compile time; in this use case it is being used to choose which attribute getter to use based on the argument type. Important to understand that what's happening here is the path is being decided during compile. So what happens in reality is **4 different functions are compiled/specialized** - one specialization for each extant path through the conditional 
    ```cpp
    getAttributeValue(const PyTorch_BoolValue &value) {
        ...
        return mlirBoolAttrGetValue(attr);
    }
    getAttributeValue(const PyTorch_FloatValue &value) {
        ...
        mlirFloatAttrGetValueDouble(attr);
    }
    ...
    ```
    i.e., it depends the calls themselves not the possible branch choices) and the whole specialization is chosen at runtime **not the branch**;
5. `std::is_same<T, PyTorch_BoolValue>` this is just an [stl helper struct](https://en.cppreference.com/w/cpp/types/is_same) that evaluates type equality (`::value` is what actually returns `true` or `false`).

[^1]: [`template <typename ...>` vs `template <class ...>` I myself am not completely clear on](https://stackoverflow.com/questions/2023977/difference-of-keywords-typename-and-class-in-templates)