### PR TITLE
Implement Tensor indexing (partial), tensor division, and list concatenation

### DIFF
--- a/cpp_ext/TorchOps.cpp
+++ b/cpp_ext/TorchOps.cpp
@@ -203,7 +203,8 @@ void populateTorchMLIROps(py::module &m) {
          const PyTorch_BoolValue &keepdim,
          const PyAnyTorchOptionalIntValue &dtype, DefaultingPyLocation &loc,
          const DefaultingPyInsertionPoint &ip) -> PyAnyTorchTensorValue {
-        return mean(self, dim, keepdim, dtype, loc.get(), ip.get());
+        auto dims = PyAnyTorchOptionalListOfTorchIntValue(py::make_tuple(dim));
+        return mean(self, dims, keepdim, dtype, loc.get(), ip.get());
       },
       "self"_a, "dim"_a = py::none(), "keepdim"_a = false,
       "dtype"_a = py::none(), py::kw_only(), "loc"_a = py::none(),

--- a/cpp_ext/TorchTensor.pybinds.cpp
+++ b/cpp_ext/TorchTensor.pybinds.cpp
@@ -40,9 +40,6 @@ c.def("__ge__", [](const PyAnyTorchTensorValue &self, const PyAnyTorchScalarValu
 // aten::ge.Tensor : (Tensor, Tensor) -> (Tensor)
 c.def("__ge__", [](const PyAnyTorchTensorValue &self, const PyAnyTorchTensorValue &other, DefaultingPyLocation &loc, const DefaultingPyInsertionPoint &ip) -> PyAnyTorchTensorValue { return __ge__(self, other, loc.get(), ip.get()); }, "other"_a, py::kw_only(), "loc"_a = py::none(), "ip"_a = py::none());
 
-// __getitem__(self, indices: Union[None, _int, slice, Tensor, List, Tuple]) -> Tensor
-c.def("__getitem__", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: __getitem__ with signature __getitem__(self, indices: Union[None, _int, slice, Tensor, List, Tuple]) -> Tensor"); });
-
 // __gt__(self, other: Any) -> Tensor
 // aten::gt.Scalar : (Tensor, Scalar) -> (Tensor)
 c.def("__gt__", [](const PyAnyTorchTensorValue &self, const PyAnyTorchScalarValue &other, DefaultingPyLocation &loc, const DefaultingPyInsertionPoint &ip) -> PyAnyTorchTensorValue { return __gt__(self, other, loc.get(), ip.get()); }, "other"_a, py::kw_only(), "loc"_a = py::none(), "ip"_a = py::none());
@@ -285,9 +282,6 @@ c.def("_nested_tensor_strides", [](PyAnyTorchTensorValue& self, py::args args, p
 
 // _nnz(self) -> _int
 c.def("_nnz", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _nnz with signature _nnz(self) -> _int"); });
-
-// _sparse_mask_projection(self, mask: Tensor) -> Tensor
-c.def("_sparse_mask_projection", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _sparse_mask_projection with signature _sparse_mask_projection(self, mask: Tensor) -> Tensor"); });
 
 // _to_dense(self, dtype: Optional[_dtype]=None, masked_grad: Optional[_bool]=None) -> Tensor
 c.def("_to_dense", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _to_dense with signature _to_dense(self, dtype: Optional[_dtype]=None, masked_grad: Optional[_bool]=None) -> Tensor"); });

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -460,6 +460,24 @@ makeListIter<PyAnyTorchTensorValue, PyAnyTorchListOfTensorValue const>(
 void PyAnyTorchListValue::bindDerived(ClassTy &c) {
   c.def(py::init<py::list>(), "value"_a);
   c.def(py::init<py::tuple>(), "value"_a);
+  c.def(
+      "__add__",
+      [](const PyAnyTorchListValue &self,
+         const PyAnyTorchListValue &other) -> PyAnyTorchListValue {
+        auto loc = getValueLocation(self);
+        return add(self, other, &loc, &DefaultingPyInsertionPoint::resolve());
+      },
+      "other"_a);
+
+  c.def(
+      "__radd__",
+      [](const PyAnyTorchListValue &self,
+         const PyAnyTorchListValue &other) -> PyAnyTorchListValue {
+        auto loc = getValueLocation(self);
+        return add(self, other, &loc, &DefaultingPyInsertionPoint::resolve());
+      },
+      "other"_a);
+
   py::implicitly_convertible<py::list, PyAnyTorchListValue>();
   py::implicitly_convertible<py::tuple, PyAnyTorchListValue>();
   c.def("__len__", [](const PyAnyTorchListValue &self) { return self.length; });

--- a/pi/__init__.py
+++ b/pi/__init__.py
@@ -17,7 +17,7 @@ from .mlir.utils import (
     LongTensor,
     TensorPlaceholder,
     dtype,
-    empty,
+    empty_placeholder,
     layout,
     memory_format,
     ones,

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -173,7 +173,7 @@ def star_args_wrapper(factory):
     return wrapper
 
 
-empty = functools.partial(_np_wrapper, factory=np.empty)
+empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
 rand = functools.partial(_np_wrapper, factory=np.random.rand)

--- a/pi/nn/parameter.py
+++ b/pi/nn/parameter.py
@@ -5,7 +5,7 @@ from functools import partial
 from typing import Union, List, Tuple
 
 
-from pi import Tensor, dtype, empty
+from pi import Tensor, dtype, empty_placeholder
 import pi
 
 
@@ -27,7 +27,7 @@ class Uninitialized(partial):
             if inspect.isfunction(func) or isinstance(func, functools.partial):
                 args = args[1:]
             else:
-                func = empty
+                func = empty_placeholder
 
             if isinstance(args[0], (tuple, list)):
                 assert len(args) == 1, f"unknown len args {args}"

--- a/scripts/generate_stuff/generate_torch_mlir_bindings_from_torch_json.py
+++ b/scripts/generate_stuff/generate_torch_mlir_bindings_from_torch_json.py
@@ -61,6 +61,7 @@ SKIP_TENSOR_BINDS = {
     "__truediv__(self, other: Any) -> Tensor",
     "__rtruediv__(self, other: Any) -> Tensor",
     "chunk(self, chunks: _int, dim: _int=0) -> List[Tensor]",
+    "__getitem__(self, indices: Union[None, _int, slice, Tensor, List, Tuple]) -> Tensor",
 }
 
 TORCH_OPS_IMPL_CPP = "TorchOps.impls.cpp"

--- a/tests/unit/test_mlir_values.py
+++ b/tests/unit/test_mlir_values.py
@@ -631,3 +631,40 @@ class TestTorchValues:
                 "Torch_StringValue(%7 = torch.aten.__getitem__.t %6, %int0 : !torch.list<str>, !torch.int -> !torch.str)",
                 t,
             )
+
+    def test_ListConcatenation(self):
+        with mlir_mod_ctx():
+            x = AnyTorchListValue([1, 2, 3])
+            y = AnyTorchListValue([4, 5])
+
+            r = x + y
+            check_correct(
+                "AnyTorchListValue(%DONT_CARE = torch.aten.add.t %DONT_CARE, %DONT_CARE : !torch.list<int>, !torch.list<int> -> !torch.list<int>)",
+                r,
+            )
+
+            py_list = [1, 2, 3]
+            r = x + py_list
+            check_correct(
+                "AnyTorchListValue(%DONT_CARE = torch.aten.add.t %DONT_CARE, %DONT_CARE : !torch.list<int>, !torch.list<int> -> !torch.list<int>)",
+                r,
+            )
+
+            r = py_list + x
+            check_correct(
+                "AnyTorchListValue(%DONT_CARE = torch.aten.add.t %DONT_CARE, %DONT_CARE : !torch.list<int>, !torch.list<int> -> !torch.list<int>)",
+                r,
+            )
+
+            py_tuple = (4, 5)
+            r = x + py_tuple
+            check_correct(
+                "AnyTorchListValue(%DONT_CARE = torch.aten.add.t %DONT_CARE, %DONT_CARE : !torch.list<int>, !torch.list<int> -> !torch.list<int>)",
+                r,
+            )
+
+            r = py_tuple + x
+            check_correct(
+                "AnyTorchListValue(%DONT_CARE = torch.aten.add.t %DONT_CARE, %DONT_CARE : !torch.list<int>, !torch.list<int> -> !torch.list<int>)",
+                r,
+            )


### PR DESCRIPTION
This PR chased down this test case: https://github.com/llvm/torch-mlir/blob/4fd4477e15a2726724d7cf18cb44421ba209da3a/python/torch_mlir_e2e_test/test_suite/rng.py#L94

Minor Fixes:
- Handle the case where torch.Tensor.reshape accepts a sequence of ints rather than a container
- Fix the aten.mean.dim impl, when passing only a single int as the dim for reduction place it in a container (else linalg lowering fails)
- Reroute pi.empty - use the cpp implementation (to create a `torch.aten.empty.memory_format` Op when necessary), renamed the NumPy wrapper for empty to empty_placeholder in order to use it for `pi.nn.Module` which relies on it to create Uninitialized parameter placeholders, this resolves a few test cases by itself.

Major Changes:
- Implement support for Tensor indexing (partial) + unit tests, supports indexing, slicing, None index, and dimension selection via `aten.select.int`
- Implement `__truediv__`, `__rtruediv__` for TensorValue class + unit tests 
- Implement `__add__`, `__radd__` for ListValue class - list concatenation + unit tests