### PR TITLE
Implement constant: torch.nan -> pi.nan

### DIFF
--- a/cpp_ext/PiExtension.cpp
+++ b/cpp_ext/PiExtension.cpp
@@ -22,4 +22,6 @@ PYBIND11_MODULE(_pi_mlir, m) {
   populateTorchDType(m);
   auto ops = m.def_submodule("ops");
   populateTorchMLIROps(ops);
+  auto constants = m.def_submodule("constants");
+  populateTorchConstants(constants);
 }

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -750,4 +750,6 @@ void populateTorchMLIRValues(py::module &m) {
   PyAnyTorchScalarValue::bind(m);
 }
 
+void populateTorchConstants(py::module &m) { m.attr("nan") = std::nanf(""); }
+
 } // namespace mlir::torch

--- a/cpp_ext/TorchValues.h
+++ b/cpp_ext/TorchValues.h
@@ -504,6 +504,7 @@ public:
 };
 
 void populateTorchMLIRValues(py::module &m);
+void populateTorchConstants(py::module &m);
 
 } // namespace mlir::torch
 

--- a/pi/__init__.py
+++ b/pi/__init__.py
@@ -3,6 +3,9 @@ import contextlib
 from .mlir import Tensor
 
 # noinspection PyUnresolvedReferences
+from .mlir._mlir_libs._pi_mlir.constants import *
+
+# noinspection PyUnresolvedReferences
 from .mlir._mlir_libs._pi_mlir import ops
 
 


### PR DESCRIPTION
This exposes a constant to the python interface for PI, allowing for us to deal with expressions involving `torch.nan`, these should generate a constant float op as follows: `%floatNaN = torch.constant.float 0x7FF8000000000000` which is handled by simply returning a float representation of NaN via `std::nanf`.