### PR TITLE
Use "dynamo" to rewrite `int(...)`, `float(...)`, and `bool(...)`

### DIFF
--- a/pi/__init__.py
+++ b/pi/__init__.py
@@ -3,19 +3,20 @@ import contextlib
 from .mlir import Tensor
 
 # noinspection PyUnresolvedReferences
-from .mlir._mlir_libs._pi_mlir.constants import *
-
-# noinspection PyUnresolvedReferences
 from .mlir._mlir_libs._pi_mlir import ops
 
+# noinspection PyUnresolvedReferences
+from .mlir._mlir_libs._pi_mlir.constants import *
 
 # note this import needs to be above the one below it so that e.g. ops.zeros is replaced by util.zeros
 # noinspection PyUnresolvedReferences
 from .mlir._mlir_libs._pi_mlir.ops import *
-
 from .mlir.utils import (
     LongTensor,
     TensorPlaceholder,
+    Torch_BoolValue,
+    Torch_IntValue,
+    Torch_FloatValue,
     dtype,
     empty,
     layout,
@@ -91,3 +92,99 @@ class backends:
 
 
 FloatTensor = tensor
+
+import builtins
+
+builtin_int = builtins.int
+builtin_bool = builtins.bool
+builtin_float = builtins.float
+
+
+class pi_bool_meta(type):
+    def __instancecheck__(self, other):
+        return isinstance(other, builtin_bool)
+
+    def __call__(self, x, base=None):
+        if isinstance(x, Tensor):
+            return ops.Bool(x)
+        elif isinstance(x, Torch_BoolValue):
+            try:
+                return builtin_bool(x)
+            except:
+                return x
+        else:
+            return builtin_bool(x)
+
+
+class pi_bool(builtin_int, metaclass=pi_bool_meta):
+    pass
+
+
+pi_bool.__name__ = builtin_bool.__name__
+pi_bool.__qualname__ = builtin_bool.__qualname__
+
+
+class pi_int_meta(type):
+    def __instancecheck__(self, other):
+        return isinstance(other, builtin_int)
+
+    def __call__(self, x, base=None):
+        if isinstance(x, Tensor):
+            return ops.Int(x)
+        elif isinstance(x, Torch_IntValue):
+            try:
+                return builtin_int(x)
+            except:
+                return x
+        else:
+            if base is not None:
+                return builtin_int(x, base)
+            else:
+                return builtin_int(x)
+
+
+class pi_int(builtin_int, metaclass=pi_int_meta):
+    pass
+
+
+pi_int.__name__ = builtin_int.__name__
+pi_int.__qualname__ = builtin_int.__qualname__
+
+
+class pi_float_meta(type):
+    def __instancecheck__(self, other):
+        return isinstance(other, builtin_float)
+
+    def __call__(self, x):
+        if isinstance(x, Tensor):
+            return ops.Float(x)
+        elif isinstance(x, Torch_FloatValue):
+            try:
+                return builtin_float(x)
+            except:
+                return x
+        else:
+            return builtin_float(x)
+
+
+class pi_float(builtin_float, metaclass=pi_float_meta):
+    pass
+
+
+pi_float.__name__ = builtin_float.__name__
+pi_float.__qualname__ = builtin_float.__qualname__
+
+
+@contextlib.contextmanager
+def swap_pi_int_float():
+    __builtins__["int"] = pi_int
+    __builtins__["bool"] = pi_bool
+    __builtins__["float"] = pi_float
+    from . import nn
+
+    yield
+
+    __builtins__["int"] = builtin_int
+    __builtins__["bool"] = builtin_bool
+    __builtins__["float"] = builtin_float
+    from . import nn

--- a/pi/mlir/__init__.py
+++ b/pi/mlir/__init__.py
@@ -90,9 +90,7 @@ from ._mlir_libs._pi_mlir import (
 )
 
 # noinspection PyUnresolvedReferences
-from ._mlir_libs._pi_mlir import Tensor, dtype
-
-Tensor = Tensor
+from ._mlir_libs._pi_mlir import Tensor, dtype, ops
 
 from .dialects import _ods_common
 from .dialects._ods_common import get_op_result_or_value, get_op_results_or_values

--- a/tests/torch_mlir/main.py
+++ b/tests/torch_mlir/main.py
@@ -29,10 +29,10 @@ from infra.path_hacks import (
     patch_meta_path,
 )
 from pi.mlir.compile import lower_pi_to_linalg
-import pi
+from pi import swap_pi_int_float
 
 ONLY = {
-    # "ChunkListUnpackUneven_Module_basic"
+    # "AtenIntTensorByteDtypeModule_basic"
 }
 
 
@@ -130,6 +130,8 @@ def run_pi_tests(torch_mlir_module_strs, sequential=False):
     tests = sorted(GLOBAL_TEST_REGISTRY.values(), key=lambda t: t.unique_name)
     assert tests, "failed to load tests"
 
+    import pi
+
     pi.nn.Module.train = lambda *args, **kwargs: None
     pi_config = PIConfig()
     num_processes = min(int(cpu_count() * 1.1), len(tests))
@@ -149,62 +151,63 @@ def run_pi_tests(torch_mlir_module_strs, sequential=False):
         )
 
     def compile_and_run_test(test):
-        if test.unique_name in CRASHING | COMMON_TORCH_MLIR_LOWERING_XFAILS or (
-            ONLY and test.unique_name not in ONLY
-        ):
-            SKIPs.append(test.unique_name)
-            return
-        logger.info(f"running {test.unique_name}")
+        with swap_pi_int_float():
+            if test.unique_name in CRASHING | COMMON_TORCH_MLIR_LOWERING_XFAILS or (
+                ONLY and test.unique_name not in ONLY
+            ):
+                SKIPs.append(test.unique_name)
+                return
+            logger.info(f"running {test.unique_name}")
 
-        (
-            torch_linalg_module,
-            torch_dialect_module,
-            torch_dialect_module_raw,
-        ) = torch_mlir_module_strs[test.unique_name]
+            (
+                torch_linalg_module,
+                torch_dialect_module,
+                torch_dialect_module_raw,
+            ) = torch_mlir_module_strs[test.unique_name]
 
-        try:
-            pi_mlir_module = pi_config.compile(test)
-        except Exception as e:
-            Exception_FAILs.append((test.unique_name, str(e)))
-            return
+            try:
+                pi_mlir_module = pi_config.compile(test)
+            except Exception as e:
+                Exception_FAILs.append((test.unique_name, str(e)))
+                return
 
-        pi_torch_dialect_module_str = str(
-            pi_mlir_module.operation.get_asm(large_elements_limit=10)
-        )
-        try:
-            pi_linalg_module_str = str(
-                lower_pi_to_linalg(
-                    pi_mlir_module, enable_ir_printing=False
-                ).operation.get_asm(large_elements_limit=10)
+            pi_torch_dialect_module_str = str(
+                pi_mlir_module.operation.get_asm(large_elements_limit=10)
             )
-        except Exception as e:
-            lower_to_linalg_FAILs.append(
-                (test.unique_name, str(e), pi_torch_dialect_module_str)
-            )
-            return
+            try:
+                pi_linalg_module_str = str(
+                    lower_pi_to_linalg(
+                        pi_mlir_module, enable_ir_printing=False
+                    ).operation.get_asm(large_elements_limit=10)
+                )
+            except Exception as e:
+                lower_to_linalg_FAILs.append(
+                    (test.unique_name, str(e), pi_torch_dialect_module_str)
+                )
+                return
 
-        sorted_diff = list(
-            difflib.unified_diff(
-                sorted(str(pi_linalg_module_str).splitlines()),
-                sorted(str(torch_linalg_module).splitlines()),
-                lineterm="",
-            )
-        )
-
-        if len(sorted_diff) and test.unique_name in PI_XFAIL_SET:
-            XFAILs.append(test.unique_name)
-        elif len(sorted_diff):
-            diff = list(
+            sorted_diff = list(
                 difflib.unified_diff(
-                    str(pi_linalg_module_str).splitlines(),
-                    str(torch_linalg_module).splitlines(),
+                    sorted(str(pi_linalg_module_str).splitlines()),
+                    sorted(str(torch_linalg_module).splitlines()),
                     lineterm="",
                 )
             )
-            ir_FAILs.append((test.unique_name, diff))
-        else:
-            logger.info("PASS")
-            return 1
+
+            if len(sorted_diff) and test.unique_name in PI_XFAIL_SET:
+                XFAILs.append(test.unique_name)
+            elif len(sorted_diff):
+                diff = list(
+                    difflib.unified_diff(
+                        str(pi_linalg_module_str).splitlines(),
+                        str(torch_linalg_module).splitlines(),
+                        lineterm="",
+                    )
+                )
+                ir_FAILs.append((test.unique_name, diff))
+            else:
+                logger.info("PASS")
+                return 1
 
     if sequential:
         handles = map(compile_and_run_test, tests)


### PR DESCRIPTION
This PR uses https://github.com/makslevental/pyframe_eval to implement our own version of dynamo and support `int(...)`, `float(...)`, and `bool(...)`, i.e., a custom stackframe evaluator that "just-in-time" rewrites the ast such that 

```python
class MyIntModule(nn.Module):
    def forward(self, x):
        y = int(x)
        return y
```

becomes (roughly)

```python
class MyIntModule(nn.Module):
    def forward(self, x):
        y = pi.pi_int(x)
        return y
```

which then gets lowered to 

```mlir
func.func @forward(%arg0: !torch.vtensor<[1],si64>) -> !torch.int {
  %0 = torch.aten.Int.Tensor %arg0 : !torch.vtensor<[1],si64> -> !torch.int
  return %0 : !torch.int
}
```

**Just to be very clear**: there's **still** no PyTorch in the mix here, I simply implemented the same thing that they did (and packaged it seperately in `pyframe_eval`) and instead of custom interpreting the bytecode of the stackframe, I made it rewrite the ast of the stackframe.

This and (`pyframe_eval`) is still not fully tested (so it might segfault or assert inside of cpython) but it basically works:

```
total # of tests: 930
total # of skips: 18
total # of passes: 741
total # of xfails: 16
total # of exceptions: 90
total # of lower to linalg failures: 25
total # of ir differences: 40
```

cc @powderluv 