### PR TITLE
Implement PyAnyTorchListOfTensorValue list indexing

### DIFF
--- a/cpp_ext/TorchTensor.cpp
+++ b/cpp_ext/TorchTensor.cpp
@@ -415,6 +415,15 @@ void PyAnyTorchListOfTensorValue::bindDerived(ClassTy &c) {
         self, &DefaultingPyLocation::resolve(),
         &DefaultingPyInsertionPoint::resolve())));
   });
+  c.def(
+      "__getitem__",
+      [](const PyAnyTorchListOfTensorValue &self,
+         const PyTorch_IntValue &idx) -> PyAnyTorchTensorValue {
+        return makeGetItem<PyAnyTorchTensorValue>(
+            self, idx, &DefaultingPyLocation::resolve(),
+            &DefaultingPyInsertionPoint::resolve());
+      },
+      "idx"_a);
 }
 
 PyAnyTorchListOfOptionalTensorValue

--- a/cpp_ext/TorchValues.cpp
+++ b/cpp_ext/TorchValues.cpp
@@ -402,6 +402,9 @@ T makeGetItem(U &self, const PyTorch_IntValue &idx, PyLocation *loc,
     t = torchMlirTorchIntTypeGet(loc->getContext()->get());
   else if (std::is_same<T, PyTorch_StringValue>::value)
     t = torchMlirTorchStringTypeGet(loc->getContext()->get());
+  else if (std::is_same<T, PyAnyTorchTensorValue>::value)
+    t = torchMlirTorchNonValueTensorTypeGetWithLeastStaticInformation(
+        loc->getContext()->get());
   else
     throw std::runtime_error("unknown element type");
   auto resultType = py::cast(t).cast<PyType>();
@@ -409,6 +412,11 @@ T makeGetItem(U &self, const PyTorch_IntValue &idx, PyLocation *loc,
       "torch.aten.__getitem__.t", {resultType}, {self, idx}, {}, loc, ip);
   return {opRef, mlirOperationGetResult(opRef->get(), 0)};
 }
+
+template PyAnyTorchTensorValue
+makeGetItem<PyAnyTorchTensorValue>(const PyAnyTorchListOfTensorValue &self,
+                                   const PyTorch_IntValue &idx, PyLocation *loc,
+                                   PyInsertionPoint *ip);
 
 MlirOperation getOwner(const PyValue &value) {
   MlirOperation owner;

--- a/cpp_ext/TorchValues.h
+++ b/cpp_ext/TorchValues.h
@@ -168,6 +168,10 @@ PyAnyTorchListValue makePyAnyTorchListValue(const py::object &type,
                                             PyLocation *loc,
                                             PyInsertionPoint *ip);
 
+template <typename T, typename U>
+T makeGetItem(U &self, const PyTorch_IntValue &idx, PyLocation *loc,
+              PyInsertionPoint *ip);
+
 class PyTorch_NoneValue : public PyConcreteValue<PyTorch_NoneValue> {
 public:
   static constexpr IsAFunctionTy isaFunction = isATorch_NoneValue;


### PR DESCRIPTION
Addresses this error `'pi.mlir._mlir_libs._pi_mlir.AnyTorchListOfTensorValue' object is not subscriptable` on these two test cases: `SplitTensorGetItem_Module_basic, UnbindIntGetItem_Module_basic`

Simple addition of `__getitem__` method to the `PyAnyTorchListOfTensorValue` class, in order to prevent code repetition I reused the template function `makeGetItem` from `TorchValues.cpp`; however in order to [ensure that the corresponding template is instantiated](https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl) for `PyAnyTorchListOfTensorValue` I included an explicit template instantiation in `TorchValues.cpp`. Another approach could be to simply move the definition of the template function into `TorchValues.h` rather than separating the declaration and definition, but this runs into some issues with circular dependencies where `TorchTensor.*` and `TorchValues.*` include one another leading to a compilation error.