### PR TITLE
simply uncommenting pi._C._nn.one_hot

### DIFF
--- a/pi/nn/functional.py
+++ b/pi/nn/functional.py
@@ -2055,7 +2055,7 @@ pad = pi._C._nn.pad
 
 # cosine_similarity = pi.cosine_similarity
 
-# one_hot = pi._C._nn.one_hot
+one_hot = pi._C._nn.one_hot
 
 
 def triplet_margin_loss(


### PR DESCRIPTION
OneHotModule_basic test was throwing the following error: `module 'pi.nn.functional' has no attribute 'one_hot'`
`one_hot = pi._C._nn.one_hot` was commented out from functional.py, so I uncommented and the test passes. 
Please let me know if there's any reason for commenting this out.