### PR TITLE
implemented random_normal_wrapper to call np.random.Generator.standar…

### DIFF
--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -173,26 +173,16 @@ def star_args_wrapper(factory):
     return wrapper
 
 
-def random_normal_wrapper(factory):
-    @functools.wraps(factory)
-    def wrapper(*args, **kwargs):
-        # Create a random number generator
-        rng = np.random.default_rng()
-        if len(args) == 1 and isinstance(args[0], (list, tuple)):
-            return factory(rng, args[0], **kwargs)
-        else:
-            return factory(rng, args, **kwargs)
+def standard_normal(*args, **kwargs):
+    rng = np.random.default_rng()
 
-    return wrapper
-
+    return np.random.Generator.standard_normal(rng, *args, **kwargs)
 
 empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
 rand = functools.partial(_np_wrapper, factory=np.random.rand)
-randn = functools.partial(
-    _np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal)
-)
+randn = functools.partial(_np_wrapper, factory=star_args_wrapper(standard_normal))
 tensor = functools.partial(_np_wrapper, factory=np.array)
 LongTensor = functools.partial(_np_wrapper, factory=np.array, dtype=dtype.int64)
 

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -173,13 +173,24 @@ def star_args_wrapper(factory):
     return wrapper
 
 
+def random_normal_wrapper(factory):
+    @functools.wraps(factory)
+    def wrapper(*args, **kwargs):
+        # Create a random number generator
+        rng = np.random.default_rng()
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            return factory(rng, args[0], **kwargs)
+        else:
+            return factory(rng, args, **kwargs)
+
+    return wrapper
+
 empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
 rand = functools.partial(_np_wrapper, factory=np.random.rand)
-randn = functools.partial(_np_wrapper, factory=np.random.randn)
+randn = functools.partial(_np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal))
 tensor = functools.partial(_np_wrapper, factory=np.array)
-
 LongTensor = functools.partial(_np_wrapper, factory=np.array, dtype=dtype.int64)
 
 

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -178,6 +178,7 @@ def standard_normal(*args, **kwargs):
 
     return np.random.Generator.standard_normal(rng, *args, **kwargs)
 
+
 empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -71,7 +71,7 @@ def disable_multithreading(context=None):
 
 @contextlib.contextmanager
 def mlir_mod_ctx(
-        src: Optional[str] = None, context: Context = None, location: Location = None
+    src: Optional[str] = None, context: Context = None, location: Location = None
 ):
     if context is None:
         context = Context()
@@ -98,7 +98,7 @@ def _i1Attr(x, context):
 
 
 def infer_mlir_type(
-        py_val: Union[int, float, bool, np.ndarray]
+    py_val: Union[int, float, bool, np.ndarray]
 ) -> Union[IntegerType, F64Type, RankedTensorType]:
     if isinstance(py_val, bool):
         return IntegerType.get_signless(1)
@@ -190,7 +190,8 @@ empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
 rand = functools.partial(_np_wrapper, factory=np.random.rand)
-randn = functools.partial(_np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal))
+randn = functools.partial(
+    _np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal))
 tensor = functools.partial(_np_wrapper, factory=np.array)
 LongTensor = functools.partial(_np_wrapper, factory=np.array, dtype=dtype.int64)
 
@@ -261,7 +262,7 @@ ArgAnnotation = Union[type, Tuple[List[int], dtype]]
 
 
 def annotations_to_placeholders(
-        args: List[str], annotations: List[Optional[ArgAnnotation]]
+    args: List[str], annotations: List[Optional[ArgAnnotation]]
 ):
     from collections import OrderedDict
 

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -191,7 +191,8 @@ ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
 rand = functools.partial(_np_wrapper, factory=np.random.rand)
 randn = functools.partial(
-    _np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal))
+    _np_wrapper, factory=random_normal_wrapper(np.random.Generator.standard_normal)
+)
 tensor = functools.partial(_np_wrapper, factory=np.array)
 LongTensor = functools.partial(_np_wrapper, factory=np.array, dtype=dtype.int64)
 

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -71,7 +71,7 @@ def disable_multithreading(context=None):
 
 @contextlib.contextmanager
 def mlir_mod_ctx(
-    src: Optional[str] = None, context: Context = None, location: Location = None
+        src: Optional[str] = None, context: Context = None, location: Location = None
 ):
     if context is None:
         context = Context()
@@ -98,7 +98,7 @@ def _i1Attr(x, context):
 
 
 def infer_mlir_type(
-    py_val: Union[int, float, bool, np.ndarray]
+        py_val: Union[int, float, bool, np.ndarray]
 ) -> Union[IntegerType, F64Type, RankedTensorType]:
     if isinstance(py_val, bool):
         return IntegerType.get_signless(1)
@@ -185,6 +185,7 @@ def random_normal_wrapper(factory):
 
     return wrapper
 
+
 empty_placeholder = functools.partial(_np_wrapper, factory=np.empty)
 ones = functools.partial(_np_wrapper, factory=star_args_wrapper(np.ones))
 zeros = functools.partial(_np_wrapper, factory=star_args_wrapper(np.zeros))
@@ -260,7 +261,7 @@ ArgAnnotation = Union[type, Tuple[List[int], dtype]]
 
 
 def annotations_to_placeholders(
-    args: List[str], annotations: List[Optional[ArgAnnotation]]
+        args: List[str], annotations: List[Optional[ArgAnnotation]]
 ):
     from collections import OrderedDict
 


### PR DESCRIPTION
Addressing the below error of unexpected kwarg dtype. 
As `np.random.randn` does not accept keyword dtype, `random.Generator.standard_normal(size=None, dtype=np.float64, out=None)` is called instead. To create a random generator, an additional wrapper function, `random_normal_wrapper`, is implemented.  

``` ScaledDotProductAttentionDifferentModule_basic, ScaledDotProductAttentionSameModule_basic
randn() got an unexpected keyword argument 'dtype```