### PR TITLE
More API Compat Fixes

### DIFF
--- a/cpp_ext/TorchTensor.pybinds.cpp
+++ b/cpp_ext/TorchTensor.pybinds.cpp
@@ -283,9 +283,6 @@ c.def("_nested_tensor_strides", [](PyAnyTorchTensorValue& self, py::args args, p
 // _nnz(self) -> _int
 c.def("_nnz", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _nnz with signature _nnz(self) -> _int"); });
 
-// _sparse_mask_projection(self, mask: Tensor) -> Tensor
-c.def("_sparse_mask_projection", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _sparse_mask_projection with signature _sparse_mask_projection(self, mask: Tensor) -> Tensor"); });
-
 // _to_dense(self, dtype: Optional[_dtype]=None, masked_grad: Optional[_bool]=None) -> Tensor
 c.def("_to_dense", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: _to_dense with signature _to_dense(self, dtype: Optional[_dtype]=None, masked_grad: Optional[_bool]=None) -> Tensor"); });
 
@@ -1751,6 +1748,10 @@ c.def("ormqr", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs)
 
 // outer(self, vec2: Tensor) -> Tensor
 c.def("outer", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: outer with signature outer(self, vec2: Tensor) -> Tensor"); });
+
+// @overload permute(self, dims: _size) -> Tensor
+// aten::permute : (Tensor, int[]) -> (Tensor)
+c.def("permute", [](const PyAnyTorchTensorValue &self, const PyAnyTorchListOfTorchIntValue &dims, DefaultingPyLocation &loc, const DefaultingPyInsertionPoint &ip) -> PyAnyTorchTensorValue { return permute(self, dims, loc.get(), ip.get()); }, "dims"_a, py::kw_only(), "loc"_a = py::none(), "ip"_a = py::none());
 
 // pin_memory(self, device: Optional[Union[_device, str, None]]=None) -> Tensor
 c.def("pin_memory", [](PyAnyTorchTensorValue& self, py::args args, py::kwargs kwargs) { throw NotImplementedError("NotImplementedError: pin_memory with signature pin_memory(self, device: Optional[Union[_device, str, None]]=None) -> Tensor"); });

--- a/pi/mlir/utils.py
+++ b/pi/mlir/utils.py
@@ -6,7 +6,7 @@ import contextlib
 import functools
 import inspect
 import warnings
-from enum import Enum
+from enum import IntEnum
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -188,7 +188,7 @@ tensor = functools.partial(_np_wrapper, factory=np.array)
 LongTensor = functools.partial(_np_wrapper, factory=np.array, dtype=dtype.int64)
 
 
-class layout(Enum):
+class layout(IntEnum):
     strided = 1
     sparse_coo = 2
     sparse_csr = 3
@@ -198,7 +198,7 @@ class layout(Enum):
     _mkldnn = 7
 
 
-class memory_format(Enum):
+class memory_format(IntEnum):
     contiguous_format = 0
     preserve_format = 1
     channels_last = 2

--- a/scripts/generate_stuff/generate_torch_mlir_bindings_from_torch_json.py
+++ b/scripts/generate_stuff/generate_torch_mlir_bindings_from_torch_json.py
@@ -63,7 +63,6 @@ SKIP_TENSOR_BINDS = {
     "chunk(self, chunks: _int, dim: _int=0) -> List[Tensor]",
     "__getitem__(self, indices: Union[None, _int, slice, Tensor, List, Tuple]) -> Tensor",
     "double(self) -> Tensor",
-    "@overload permute(self, dims: _size) -> Tensor",
 }
 
 TORCH_OPS_IMPL_CPP = "TorchOps.impls.cpp"

--- a/tests/torch_mlir/xfail.py
+++ b/tests/torch_mlir/xfail.py
@@ -17,6 +17,8 @@ CRASHING = {
 }
 
 PI_XFAIL_SET = {
+
+    # In these, torch-mlir spuriously initializes tensors as double precision and truncates to floating point, we simply initialize as single-precision causing an IR diff
     "ElementwiseGeFloatScalarModule_basic",
     "ArangeStartNegativeStepFloatModule_basic",
     "ArangeStartStepFloatModule_basic",
@@ -33,4 +35,7 @@ PI_XFAIL_SET = {
     "ThresholdBackward3dFloatModule_basic",
     "TypePromotionAlphaWiderModule_basic",
     "TypePromotionSameCategoryZeroRankWider_basic",
+
+    # An IR difference due to an additional pass in torch-mlir, but functionally the same
+    "NormalizeModule_basic"
 }


### PR DESCRIPTION
This contributes the following:

- Implement `torch.tensor.add`
- Implement `torch.tensor.norm` - this resolves the expected test case's API issue (NormalizeModule_basic) but results in an IR failure due to some additional pass in torch-mlir lowering the `torch.aten.norm.ScalarOpt_dim` to `torch.aten.linalg_vector_norm` using the operand value, however we match the raw IR so I added this to xfails, as it is functionally the same.
- Added back the permute pybind to autogeneration script and addressed some failing cases for permute due to the precedence of the `*args` signature, adding back the original pybind is still necessary to handle the case where dims is passed by keyword
- Change the base class for the `layout` and `memory_layout` enum classes to `IntEnum` so that they can be readily converted to integers where necessary, this resolves issues of the type: 

```
1 : ElementwiseCloneChannelsLastMemoryFormatModule_basic
 clone(): incompatible function arguments. The following argument types are supported:
     1. (self: pi.mlir._mlir_libs._pi_mlir.Tensor, memory_format: pi.mlir._mlir_libs._pi_mlir.AnyTorchOptionalIntValue = None, *, loc: mlir.ir.Location = None, ip: mlir.ir.InsertionPoint = None) -> pi.mlir._mlir_libs._pi_mlir.Tensor

 Invoked with: Tensor(<block argument> of type '!torch.tensor' at index: 0); kwargs: memory_format=<memory_format.channels_last: 2>

```


While this last change does resolve a number of test cases, it is worth noting that for one case: `ToDtypeLayoutStridedModule_basic` the API failure is resolved but the case still fails due to:

```
Failure while executing pass pipeline:
error: unknown: found an op that was marked as backend illegal
note: unknown: see current operation: %4 = "torch.aten.to.dtype_layout"(%arg0, %3, %2, %1, %1, %0, %0, %1) : (!torch.vtensor<[?,?],f32>, !torch.int, !torch.int, !torch.none, !torch.none, !torch.bool, !torch.bool, !torch.none) -> !torch.vtensor<[?,?],f64>
note: unknown: this is likely due to DecomposeComplexOps being unable to decompose this op
```

emitted from [here](https://github.com/llvm/torch-mlir/blob/50f5b658b6dc50f664d78c89c403149b064fb59b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp#L160)

I couldn't find a decomposition for this op (`aten.to.dtype_layout`) in `DecomposeComplexOps.cpp` so this may be something missing from torch-mlir, but if its better to remove it from the PR that's fine too - this is only relevant to changing the `layout` enum. @makslevental 