### PR TITLE
Update XFAIL sets

### DIFF
--- a/tests/torch_mlir/main.py
+++ b/tests/torch_mlir/main.py
@@ -16,7 +16,7 @@ from multiprocess.pool import Pool
 # noinspection PyUnresolvedReferences
 import torch_mlir
 
-from xfail import CRASHING, PI_XFAIL_SET
+from xfail import CRASHING, PI_XFAIL_SET, PI_XFAIL_EXCEPTION_SET
 
 from torch_mlir_e2e_test.test_suite import COMMON_TORCH_MLIR_LOWERING_XFAILS
 from torch_mlir_e2e_test.test_suite import (
@@ -165,7 +165,10 @@ def run_pi_tests(torch_mlir_module_strs, sequential=False):
         try:
             pi_mlir_module = pi_config.compile(test)
         except Exception as e:
-            Exception_FAILs.append((test.unique_name, str(e)))
+            if test.unique_name in PI_XFAIL_EXCEPTION_SET:
+                XFAILs.append(test.unique_name)
+            else:
+                Exception_FAILs.append((test.unique_name, str(e)))
             return
 
         pi_torch_dialect_module_str = str(

--- a/tests/torch_mlir/xfail.py
+++ b/tests/torch_mlir/xfail.py
@@ -1,3 +1,4 @@
+# These test cases crash, preventing the remaining tests from executing
 CRASHING = {
     "ArangeNegativeStartIntModule_basic",
     "ArangeStartNegativeStepIntModule_basic",
@@ -20,9 +21,10 @@ CRASHING = {
     "NativeDropoutTrainStaticShapeModule_basic",
 }
 
+# These test cases are expected to fail due to an acceptable difference in generated IR
 PI_XFAIL_SET = {
-
-    # In these, torch-mlir spuriously initializes tensors as double precision and truncates to floating point, we simply initialize as single-precision causing an IR diff
+    # In these cases, torch-mlir spuriously initializes constants as double precision and truncates to floating point,
+    # we simply initialize as single-precision causing an IR diff
     "ElementwiseGeFloatScalarModule_basic",
     "ArangeStartNegativeStepFloatModule_basic",
     "ArangeStartStepFloatModule_basic",
@@ -30,6 +32,7 @@ PI_XFAIL_SET = {
     "ElementwiseLeakyReluModule_basic",
     "ElementwiseLeakyReluStaticModule_basic",
     "ElementwiseLeFloatScalarModule_basic",
+    "ElementwiseLtFloatScalarModule_basic",
     "ElementwiseGtFloatScalarModule_basic",
     "ElementwiseSubScalarFloatModule_basic",
     "HardtanhBackward_basic",
@@ -39,7 +42,44 @@ PI_XFAIL_SET = {
     "ThresholdBackward3dFloatModule_basic",
     "TypePromotionAlphaWiderModule_basic",
     "TypePromotionSameCategoryZeroRankWider_basic",
+    "NormalizeModule_basic",
+    "NativeBatchNormNoneWeightModule_basic",
+    "NativeBatchNorm3DModule_basic",
+    "NativeBatchNorm2DModule_basic",
+    "NativeBatchNorm1DModule_basic",
+    # These test cases fail due to a difference in how PI generates some constant tensors as opposed to torch-mlir.
+    # PI straightforwardly emits a constant tensor (arith.constant dense<0.0>...), whereas torch-mlir instead emits a
+    # tensor.empty() and linalg.fill() instruction to achieve the same result
+    "OnesModuleCPUDevice_basic",
+    "OnesModuleDefaultDtype_basic",
+    "OnesModuleFalsePinMemory_basic",
+    "OnesModuleFloat_basic",
+    "OnesModuleInt_basic",
+    "TensorFloatModule_basic",
+    "TensorIntModule_basic",
+    "ZerosModuleDefaultDtype_basic",
+    "ZerosModuleFalsePinMemory_basic",
+    "ZerosModuleFloat2D_basic",
+    "ZerosModuleFloat3D_basic",
+    "ZerosModuleInt2D_basic",
+    "ZerosModuleInt3D_basic",
+    # These test cases fail due to trivial differences in constant floating point values, for example:
+    # %cst = arith.constant -0.0099999997764825821 : f64 versus %cst = arith.constant -1.000000e-02 : f64
+    # %cst = arith.constant 15.300000190734863 : f64 versus %cst = arith.constant 1.530000e+01 : f64
+    "MaskedFillScalarFloatValueStaticModule_basic",
+    "MaskedFillScalarFloatValueModule_basic",
+    "FullLikeModuleFloat3DStatic_basic",
+}
 
-    # An IR difference due to an additional pass in torch-mlir, but functionally the same
-    "NormalizeModule_basic"
+# These test cases are expected to fail due to an exception when attempting to generate the corresponding IR
+PI_XFAIL_EXCEPTION_SET = {
+    # Failure as a result of calling torch ops outside the test_module (i.e. in the program_invoker), this throws an
+    # error as `TensorPlaceholder` is passed in place of the expected `Tensor` object. Currently, PI only supports
+    # calling torch ops within the `forward` call of a `Module`
+    "AtenComplexRealModule_basic",
+    "BucketizeTensorFloatModule_basic",
+    "BucketizeTensorStaticFloatModule_basic",
+    "AtenComplexImagModule_basic",
+    "HBC_basic",
+    "ElementwiseAtenLogicalOrOpNegativeModule_basic",
 }


### PR DESCRIPTION
Updates our XFAIL sets and provides descriptions of each failure case. Adds another set: `PI_XFAIL_EXCEPTION_SET` to explicitly handle cases where exceptions occur, as these are not caught by simply placing them in the original `PI_XFAIL_SET` due to the logic in main.py - also it makes sense to partition these two cases.